### PR TITLE
LMNT: Indexing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,3 +485,6 @@ pip-selfcheck.json
 build*/
 
 # End of https://www.gitignore.io/api/python,csharp,visualstudiocode
+
+# vim swap files
+*.swp

--- a/LMNT/cmake/FetchDynASM.cmake
+++ b/LMNT/cmake/FetchDynASM.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(dynasm
     GIT_REPOSITORY https://github.com/Esvandiary/dynasm
-    GIT_TAG        f0158e129401b934cf49c8017426fd2bf99799c0
+    GIT_TAG        a51589334fe9edde22e1cd4020bece5b6459a5fb
     GIT_SHALLOW    true)
 FetchContent_GetProperties(dynasm)
 if (NOT dynasm_POPULATED)

--- a/LMNT/cmake/FetchDynASM.cmake
+++ b/LMNT/cmake/FetchDynASM.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(dynasm
     GIT_REPOSITORY https://github.com/Esvandiary/dynasm
-    GIT_TAG        2fd96bb2aa096e07d91cd67d96460be68aa313cf
+    GIT_TAG        141de6b19afc137953d15ed2c720934ad4899ea9
     GIT_SHALLOW    true)
 FetchContent_GetProperties(dynasm)
 if (NOT dynasm_POPULATED)

--- a/LMNT/cmake/FetchDynASM.cmake
+++ b/LMNT/cmake/FetchDynASM.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(dynasm
     GIT_REPOSITORY https://github.com/Esvandiary/dynasm
-    GIT_TAG        a51589334fe9edde22e1cd4020bece5b6459a5fb
+    GIT_TAG        418f782d25484e24ca0a8155ccb6f74d29579fe6
     GIT_SHALLOW    true)
 FetchContent_GetProperties(dynasm)
 if (NOT dynasm_POPULATED)

--- a/LMNT/cmake/FetchDynASM.cmake
+++ b/LMNT/cmake/FetchDynASM.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(dynasm
     GIT_REPOSITORY https://github.com/Esvandiary/dynasm
-    GIT_TAG        418f782d25484e24ca0a8155ccb6f74d29579fe6
+    GIT_TAG        2fd96bb2aa096e07d91cd67d96460be68aa313cf
     GIT_SHALLOW    true)
 FetchContent_GetProperties(dynasm)
 if (NOT dynasm_POPULATED)

--- a/LMNT/include/lmnt/common.h
+++ b/LMNT/include/lmnt/common.h
@@ -91,7 +91,7 @@ typedef struct lmnt_ictx lmnt_ictx;
         return ok_or_return_result; \
 }
 
-#define LMNT_COMBINE_OFFSET(lo, hi) (lo | (hi << sizeof(lmnt_offset) * CHAR_BIT))
+#define LMNT_COMBINE_OFFSET(lo, hi) (lo | (hi << (sizeof(lmnt_offset) * CHAR_BIT)))
 
 // MSVC does not currently include the C11-standard _Static_assert, only the C++-style variant
 #if defined(_MSC_VER)

--- a/LMNT/include/lmnt/config.h
+++ b/LMNT/include/lmnt/config.h
@@ -35,14 +35,4 @@
 #define LMNT_PRINTF printf
 #endif
 
-
-//
-// JIT settings
-//
-
-#define LMNT_JIT_COLLECT_STATS
-// #define LMNT_JIT_DEBUG_PRINT
-// #define LMNT_JIT_DEBUG_NO_REGCACHE
-// #define LMNT_JIT_DEBUG_VALIDATE_REGCACHE
-
 #endif

--- a/LMNT/include/lmnt/interpreter.h
+++ b/LMNT/include/lmnt/interpreter.h
@@ -27,6 +27,7 @@ struct lmnt_ictx
     // current def data
     const lmnt_def* cur_def;
     lmnt_loffset cur_instr;
+    size_t cur_stack_count;
     const lmnt_op_fn* op_functions;
 };
 

--- a/LMNT/include/lmnt/jit.h
+++ b/LMNT/include/lmnt/jit.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "lmnt/config.h"
+#include "lmnt/jitconfig.h"
+
 typedef lmnt_result(*lmnt_jit_fn)(lmnt_ictx* ctx);
 
 typedef struct

--- a/LMNT/include/lmnt/jitconfig.h
+++ b/LMNT/include/lmnt/jitconfig.h
@@ -1,0 +1,34 @@
+#if !defined(LMNT_JITCONFIG_H)
+#define LMNT_JITCONFIG_H
+
+#include "lmnt/platform.h"
+
+//
+// JIT settings
+//
+
+#define LMNT_JIT_COLLECT_STATS
+// #define LMNT_JIT_DEBUG_PRINT
+// #define LMNT_JIT_DEBUG_NO_REGCACHE
+// #define LMNT_JIT_DEBUG_VALIDATE_REGCACHE
+
+#if defined(LMNT_JIT_MEMORY_HEADER)
+#include LMNT_JIT_MEMORY_HEADER
+#endif
+
+// Signature: void* fn(size_t)
+#if !defined(LMNT_JIT_ALLOC_CFN_MEMORY)
+#define LMNT_JIT_ALLOC_CFN_MEMORY(sz) hostAllocMemory(sz)
+#endif
+
+// Signature: void fn(void*, size_t)
+#if !defined(LMNT_JIT_PROTECT_CFN_MEMORY)
+#define LMNT_JIT_PROTECT_CFN_MEMORY(buf, sz) hostProtectMemory((buf), (sz))
+#endif
+
+// Signature: void fn(void*, size_t)
+#if !defined(LMNT_JIT_FREE_CFN_MEMORY)
+#define LMNT_JIT_FREE_CFN_MEMORY(buf, sz) hostFreeCompiledBuffer((buf), (sz))
+#endif
+
+#endif

--- a/LMNT/include/lmnt/opcodes.h
+++ b/LMNT/include/lmnt/opcodes.h
@@ -72,12 +72,8 @@ enum
     LMNT_OP_CEILV,
     // indexing: stackref, immediate, stack
     LMNT_OP_INDEXDIS,
-    // indexing: stack, stack, stack
-    LMNT_OP_INDEXSSS,
-    // indexing: stackref, stack, stack
-    LMNT_OP_INDEXDSS,
-    // indexing: stackref, stack, stackref
-    LMNT_OP_INDEXDSD,
+    // indexing: stackref, immediate, stackref
+    LMNT_OP_INDEXDID,
     // extern call: deflo, defhi, imm
     LMNT_OP_EXTCALL,
     // placeholder end operation

--- a/LMNT/include/lmnt/ops_misc.h
+++ b/LMNT/include/lmnt/ops_misc.h
@@ -16,9 +16,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_assigniiv(lmnt_ictx* ctx, lmnt_offset arg1, l
 LMNT_ATTR_FAST lmnt_result lmnt_op_assignibv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdis(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexsss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexdss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexdsd(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+LMNT_ATTR_FAST lmnt_result lmnt_op_indexdid(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_interrupt(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 

--- a/LMNT/src/lmnt/helpers.h
+++ b/LMNT/src/lmnt/helpers.h
@@ -47,4 +47,10 @@ static inline lmnt_offset value_to_offset(lmnt_value v)
     return ((lmnt_offset)v) - (v < (lmnt_offset)v);
 }
 
+static inline size_t value_to_size_t(lmnt_value v)
+{
+    // fast floor
+    return ((size_t)v) - (v < (size_t)v);
+}
+
 #endif

--- a/LMNT/src/lmnt/interpreter.c
+++ b/LMNT/src/lmnt/interpreter.c
@@ -21,7 +21,7 @@ lmnt_result lmnt_ictx_init(lmnt_ictx* ctx, char* mem, size_t mem_size)
     ctx->memory_area_size = mem_size;
 
     // Determine how much space we want to use for frames/stack
-    const size_t min_stack_count = 256;
+    const size_t min_stack_count = 16;
     if (mem_size < min_stack_count * sizeof(lmnt_value))
         return LMNT_ERROR_MEMORY_SIZE;
 

--- a/LMNT/src/lmnt/interpreter.c
+++ b/LMNT/src/lmnt/interpreter.c
@@ -27,6 +27,9 @@ lmnt_result lmnt_ictx_init(lmnt_ictx* ctx, char* mem, size_t mem_size)
 
     ctx->archive.data = NULL;
     ctx->archive.size = 0;
+    ctx->cur_def = NULL;
+    ctx->cur_instr = 0;
+    ctx->cur_stack_count = 0;
     return LMNT_OK;
 }
 
@@ -138,8 +141,10 @@ LMNT_ATTR_FAST static lmnt_result execute(lmnt_ictx* ctx, lmnt_value* rvals, con
     }
 
     // If we finished or hit an error, clear the context's current def
-    if (LMNT_LIKELY(opresult != LMNT_INTERRUPTED))
+    if (LMNT_LIKELY(opresult != LMNT_INTERRUPTED)) {
         ctx->cur_def = NULL;
+        ctx->cur_stack_count = 0;
+    }
 
     // If OK and we have a buffer to write to, copy out return values and return the count populated
     if (LMNT_LIKELY(opresult == LMNT_OK && rvals))
@@ -162,6 +167,9 @@ LMNT_ATTR_FAST lmnt_result lmnt_execute(
     // Set our current instruction to be the start of the requested def
     ctx->cur_def = def;
     ctx->cur_instr = 0;
+    lmnt_offset consts_count = 0;
+    LMNT_OK_OR_RETURN(lmnt_get_constants_count(&ctx->archive, &consts_count));
+    ctx->cur_stack_count = (size_t)consts_count + def->stack_count_unaligned;
     // Run main execute loop
     return execute(ctx, rvals, rvals_count);
 }

--- a/LMNT/src/lmnt/jit.c
+++ b/LMNT/src/lmnt/jit.c
@@ -115,6 +115,6 @@ lmnt_result lmnt_jit_compile_with_stats(lmnt_ictx* ctx, const lmnt_def* def, lmn
 
 lmnt_result lmnt_jit_delete_function(lmnt_jit_fn_data* fndata)
 {
-    hostFreeCompiledBuffer(fndata->buffer, fndata->codesize);
+    LMNT_JIT_FREE_CFN_MEMORY(fndata->buffer, fndata->codesize);
     return LMNT_OK;
 }

--- a/LMNT/src/lmnt/jit.c
+++ b/LMNT/src/lmnt/jit.c
@@ -25,7 +25,11 @@ LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
     assert(ctx && ctx->archive.data);
     assert(ctx->stack && ctx->stack_count);
 
-    // const lmnt_def* const def = ctx->cur_def;
+    ctx->cur_def = def;
+    ctx->cur_instr = (lmnt_loffset)-1;
+    lmnt_offset consts_count = 0;
+    LMNT_OK_OR_RETURN(lmnt_get_constants_count(&ctx->archive, &consts_count));
+    ctx->cur_stack_count = (size_t)consts_count + def->stack_count_unaligned;
 
     if (LMNT_UNLIKELY(rvals && rvals_count < def->rvals_count))
         return LMNT_ERROR_RVALS_MISMATCH;
@@ -46,8 +50,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
     }
 
     // If we finished or hit an error, clear the context's current def
-    if (LMNT_LIKELY(opresult != LMNT_INTERRUPTED))
+    if (LMNT_LIKELY(opresult != LMNT_INTERRUPTED)) {
         ctx->cur_def = NULL;
+        ctx->cur_stack_count = 0;
+    }
 
     // If OK and we have a buffer to write to, copy out return values and return the count populated
     if (LMNT_LIKELY(opresult == LMNT_OK && rvals))

--- a/LMNT/src/lmnt/jit/jit-armv7m.dasc
+++ b/LMNT/src/lmnt/jit/jit-armv7m.dasc
@@ -26,7 +26,13 @@
 | .define rStack, r11
 // TODO: scalar vs vector?
 | .define vtmps1, 4
-| .define vtmps2, 0
+| .define vtmps2, 5
+| .define vtmps3, 6
+| .define vtmps4, 7
+| .define vtmps5, 0
+| .define vtmps6, 1
+| .define vtmps7, 2
+| .define vtmps8, 3
 | .define vtmpv1, 4
 | .define vtmpv2, 0
 
@@ -209,6 +215,12 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     dasm_growpc(&state->dasm_state, npc);
 
     dasm_State** Dst = &state->dasm_state;
+    | .rodata
+    | ->nanbits:
+    | .long 0x7FC00000, 0x7FC00000, 0x7FC00000, 0x7FC00000
+    | ->inftonanbits:
+    | .long 0x00400000, 0x00400000, 0x00400000, 0x00400000
+
     | .code
     | ->lmnt_main:
     | prologue, use_nv
@@ -220,7 +232,13 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     const lmnt_loffset icount = defcode->instructions_count;
     size_t reg1, reg2, reg3; // scratch
     size_t rmode; // VFP rounding mode
-    | setrmode RMODE_NEGINF, r0
+    // Set rounding mode and clear any FP exceptions
+    | vmrs r0
+    | bic r0, r0, #0x00C00000
+    | bic r0, r0, #0x1F
+    | orr r0, r0, #(RMODE_NEGINF)
+    | vmsr r0
+    ||rmode = RMODE_NEGINF;
 
     lmnt_result result = LMNT_OK;
 
@@ -424,10 +442,10 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         ||platformWriteAndEvictVolatile(state);
         |.rodata
         |1:
-        | .ilong (intptr_t)fn
+        | .long (intptr_t)(&fn)
         |.code
-        | ldr r0, <1
-        | blx r0
+        | ldr r1, <1
+        | blx r1
         ||if (acquireScalarRegister(state, outarg + offset, &outreg, ACCESSTYPE_WRITE)) {
             | vmov.f32 s(outreg), s0
             ||notifyRegisterWritten(state, outreg, 1);
@@ -446,10 +464,10 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         ||platformWriteAndEvictVolatile(state);
         |.rodata
         |1:
-        | .ilong (intptr_t)fn
+        | .long (intptr_t)(&fn)
         |.code
-        | ldr r0, <1
-        | blx r0
+        | ldr r1, <1
+        | blx r1
         ||if (acquireScalarRegister(state, in.arg3 + offset3, &reg3, ACCESSTYPE_WRITE)) {
             | vmov.f32 s(reg3), s0
             ||notifyRegisterWritten(state, reg3, 1);
@@ -500,19 +518,19 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
 
 
         case LMNT_OP_POWSS:
-            | extern2 powf,  0,  0,  0
+            | extern2 powf, 0, 0, 0
             break;
         case LMNT_OP_POWVV:
-            | extern2 powf,  0,  0,  0
-            | extern2 powf,  4,  4,  4
-            | extern2 powf,  8,  8,  8
-            | extern2 powf, 12, 12, 12
+            | extern2 powf, 0, 0, 0
+            | extern2 powf, 1, 1, 1
+            | extern2 powf, 2, 2, 2
+            | extern2 powf, 3, 3, 3
             break;
         case LMNT_OP_POWVS:
-            | extern2 powf,  0,  0,  0
-            | extern2 powf,  4,  0,  4
-            | extern2 powf,  8,  0,  8
-            | extern2 powf, 12,  0, 12
+            | extern2 powf, 0, 0, 0
+            | extern2 powf, 1, 0, 1
+            | extern2 powf, 2, 0, 2
+            | extern2 powf, 3, 0, 3
             break;
         case LMNT_OP_SQRTS:
             | maths1 vsqrt.f32
@@ -693,28 +711,42 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | writev_or_notify reg3, in.arg3, vtmpv1
             break;
 
+        |.macro round_with_nan_check, dst, src, jmp_if_bad
+        | vcvtr.s32.f32 s(dst), s(src)
+        || // NaN check
+        | vmrs r1
+        | and r2, r1, #0x0F
+        | cmp r2, #0
+        | beq >1
+        | bic r1, r1, #0x0F
+        | vmsr r1
+        | vmov.f32 s(dst), s(src)  // propagate NaN
+        | b jmp_if_bad
+        |1:
+        | vcvt.f32.s32  s(dst), s(dst)
+        |.endmacro
 
         |.macro rounds1, mode
         ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmps1);
         ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmps2);
         | ensurermode mode, r0
-        | vcvtr.s32.f32 s(reg3), s(reg1)
-        | vcvt.f32.s32  s(reg3), s(reg3)
+        | round_with_nan_check reg3, reg1, >2
+        |2:
         | writes_or_notify reg3, in.arg3, vtmps1
         |.endmacro
     
         |.macro roundv1, mode
         ||acquireVectorRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmpv1);
         ||acquireVectorRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmpv2);
-        | ensurermode RMODE_NEGINF, r0
-        | vcvtr.s32.f32 s(reg3 + 0), s(reg1 + 0)
-        | vcvt.f32.s32  s(reg3 + 0), s(reg3 + 0)
-        | vcvtr.s32.f32 s(reg3 + 1), s(reg1 + 1)
-        | vcvt.f32.s32  s(reg3 + 1), s(reg3 + 1)
-        | vcvtr.s32.f32 s(reg3 + 2), s(reg1 + 2)
-        | vcvt.f32.s32  s(reg3 + 2), s(reg3 + 2)
-        | vcvtr.s32.f32 s(reg3 + 3), s(reg1 + 3)
-        | vcvt.f32.s32  s(reg3 + 3), s(reg3 + 3)
+        | ensurermode mode, r0
+        | round_with_nan_check reg3 + 0, reg1 + 0, >2
+        |2:
+        | round_with_nan_check reg3 + 1, reg1 + 1, >2
+        |2:
+        | round_with_nan_check reg3 + 2, reg1 + 2, >2
+        |2:
+        | round_with_nan_check reg3 + 3, reg1 + 3, >2
+        |2:
         | writev_or_notify reg3, in.arg3, vtmpv1
         |.endmacro
 

--- a/LMNT/src/lmnt/jit/jit-armv7m.dasc
+++ b/LMNT/src/lmnt/jit/jit-armv7m.dasc
@@ -268,9 +268,16 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             if (in.arg1 != in.arg3) {
                 if (acquireVectorRegister(state, in.arg1, &reg1, ACCESSTYPE_READ)) {
                     if (acquireVectorRegister(state, in.arg3, &reg3, ACCESSTYPE_WRITE)) {
-                        // :(
-                        | vmov.f64 d(reg3/2 + 0), d(reg1/2 + 0)
-                        | vmov.f64 d(reg3/2 + 1), d(reg1/2 + 1)
+                        if ((reg3 % 2) == 0 && (reg1 % 2) == 0) {
+                            | vmov.f64 d(reg3/2 + 0), d(reg1/2 + 0)
+                            | vmov.f64 d(reg3/2 + 1), d(reg1/2 + 1)
+                        } else {
+                            // :(
+                            | vmov.f32 s(reg3 + 0), s(reg1 + 0)
+                            | vmov.f32 s(reg3 + 1), s(reg1 + 1)
+                            | vmov.f32 s(reg3 + 2), s(reg1 + 2)
+                            | vmov.f32 s(reg3 + 3), s(reg1 + 3)
+                        }
                         notifyRegisterWritten(state, reg3, 4);
                     } else {
                         | writev in.arg3, reg1
@@ -283,21 +290,26 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             }
             break;
         case LMNT_OP_ASSIGNSV:
-            // TODO
             ||acquireVectorRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmpv1);
             if (acquireScalarRegister(state, in.arg1, &reg1, ACCESSTYPE_READ)) {
-                // | movss xmm(reg3), xmm(reg1)
-                // | shufps xmm(reg3), xmm(reg3), 0
-                // | writev_or_notify reg3, in.arg3, vtmpv1
+                | vmov.f32 s(reg3 + 0), s(reg1)
+                | vmov.f32 s(reg3 + 1), s(reg1)
+                if ((reg3 % 2) == 0) {
+                    | vmov.f64 d(reg3/2 + 1), d(reg3/2 + 0)
+                } else {
+                    | vmov.f32 s(reg3 + 2), s(reg1)
+                    | vmov.f32 s(reg3 + 3), s(reg1)
+                }
+                | writev_or_notify reg3, in.arg3, vtmpv1
             } else {
-                // | reads xmm(reg3), in.arg1
-                // | shufps xmm(reg3), xmm(reg3), 0
-                // | writev_or_notify reg3, in.arg3, vtmpv1
+                | readv reg3, in.arg1
+                | writev_or_notify reg3, in.arg3, vtmpv1
             }
             break;
         case LMNT_OP_ASSIGNIIS:
         {
-            const lmnt_loffset off = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
+            const lmnt_loffset uoff = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
+            const int32_t off = *(const int32_t*)(&uoff);
             const lmnt_value val = (const lmnt_value)off;
             const lmnt_loffset bin = *(const lmnt_loffset*)(&val);
             | .rodata
@@ -323,8 +335,8 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         }
         case LMNT_OP_ASSIGNIIV:
         {
-            // TOOPT
-            const lmnt_loffset off = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
+            const lmnt_loffset uoff = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
+            const int32_t off = *(const int32_t*)(&uoff);
             const lmnt_value val = (const lmnt_value)off;
             const lmnt_loffset bin = *(const lmnt_loffset*)(&val);
             | .rodata
@@ -332,21 +344,20 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | .long bin, bin, bin, bin
             | .code
             ||acquireVectorRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmpv1);
-            | ldr rtmp1, <1
+            | adr rtmp1, <1
             | vldm rtmp1, {s(reg3)-s(reg3+3)}
             | writev_or_notify reg3, in.arg3, vtmpv1
             break;
         }
         case LMNT_OP_ASSIGNIBV:
         {
-            // TOOPT
             const lmnt_loffset bin = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
             | .rodata
             |1:
             | .long bin, bin, bin, bin
             | .code
             ||acquireVectorRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmpv1);
-            | ldr rtmp1, <1
+            | adr rtmp1, <1
             | vldm rtmp1, {s(reg3)-s(reg3+3)}
             | writev_or_notify reg3, in.arg3, vtmpv1
             break;

--- a/LMNT/src/lmnt/jit/jit-armv7m.dasc
+++ b/LMNT/src/lmnt/jit/jit-armv7m.dasc
@@ -227,17 +227,18 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
 
     // store LMNT stack base
     const size_t ctx_stack_offset = offsetof(lmnt_ictx, stack);
+    const size_t ctx_stack_count_offset = offsetof(lmnt_ictx, cur_stack_count);
     | ldr rStack, [rArg1, #(ctx_stack_offset)]
 
     const lmnt_loffset icount = defcode->instructions_count;
     size_t reg1, reg2, reg3; // scratch
     size_t rmode; // VFP rounding mode
     // Set rounding mode and clear any FP exceptions
-    | vmrs r0
-    | bic r0, r0, #0x00C00000
-    | bic r0, r0, #0x1F
-    | orr r0, r0, #(RMODE_NEGINF)
-    | vmsr r0
+    | vmrs rtmp1
+    | bic rtmp1, rtmp1, #0x00C00000
+    | bic rtmp1, rtmp1, #0x1F
+    | orr rtmp1, rtmp1, #(RMODE_NEGINF)
+    | vmsr rtmp1
     ||rmode = RMODE_NEGINF;
 
     lmnt_result result = LMNT_OK;
@@ -740,7 +741,7 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         |.macro rounds1, mode
         ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmps1);
         ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmps2);
-        | ensurermode mode, r0
+        | ensurermode mode, rtmp1
         | round_with_nan_check reg3, reg1, >2
         |2:
         | writes_or_notify reg3, in.arg3, vtmps1
@@ -749,7 +750,7 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         |.macro roundv1, mode
         ||acquireVectorRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmpv1);
         ||acquireVectorRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmpv2);
-        | ensurermode mode, r0
+        | ensurermode mode, rtmp1
         | round_with_nan_check reg3 + 0, reg1 + 0, >2
         |2:
         | round_with_nan_check reg3 + 1, reg1 + 1, >2
@@ -781,9 +782,105 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             break;
 
         case LMNT_OP_INDEXDIS:
-        case LMNT_OP_INDEXDID:
-            // not up to these yet :(
+        {
+            // Unknown at compile-time what stack addresses this is going to read from. So...
+            flushAllRegisters(state);
+
+            const uint32_t offset = (uint32_t)in.arg2;
+            | .rodata
+            |1:
+            | .long offset
+            | .code
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmps2);
+            // Check for NaN/infinities
+            | vmov rtmp1, s(reg1)
+            | ldr rtmp2, ->inftonanbits
+            | orr rtmp1, rtmp1, rtmp2
+            | ldr rtmp2, ->nanbits
+            | and rtmp1, rtmp1, rtmp2
+            | cmp rtmp1, rtmp2
+            | beq ->invalid_access
+            // float -> int
+            | vcvt.s32.f32 s(vtmps2), s(reg1)
+            | vmov rtmp1, s(vtmps2)
+            // index += offset
+            | ldr rtmp2, <1
+            | add rtmp1, rtmp1, rtmp2
+            // index >= stack_count?
+            | ldr rtmp2, [rArg1, #(ctx_stack_count_offset)]
+            | cmp rtmp2, rtmp1
+            | bls ->invalid_access
+            // address = stack_address + index*sizeof(lmnt_value)
+            | lsl rtmp1, rtmp1, #((int)log2f(sizeof(lmnt_value)))
+            | add rtmp1, rtmp1, rStack
+            ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmps1);
+            | vldr s(reg3), [rtmp1]
+            | writes_or_notify reg3, in.arg3, vtmps1
             break;
+        }
+        case LMNT_OP_INDEXDID:
+        {
+            // Unknown at compile-time what stack addresses this is going to read from OR WRITE TO. So...
+            platformWriteAndEvictAll(state);
+
+            const uint32_t offset = (uint32_t)in.arg2;
+            | .rodata
+            |1:
+            | .long offset
+            | .code
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmps2);
+            // arg1: check for NaN/infinities
+            | vmov rtmp1, s(reg1)
+            | ldr rtmp2, ->inftonanbits
+            | orr rtmp1, rtmp1, rtmp2
+            | ldr rtmp2, ->nanbits
+            | and rtmp1, rtmp1, rtmp2
+            | cmp rtmp1, rtmp2
+            | beq ->invalid_access
+            ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_READ, vtmps1);
+            // arg3: check for NaN/infinities
+            | vmov rtmp1, s(reg3)
+            | ldr rtmp2, ->inftonanbits
+            | orr rtmp1, rtmp1, rtmp2
+            | ldr rtmp2, ->nanbits
+            | and rtmp1, rtmp1, rtmp2
+            | cmp rtmp1, rtmp2
+            | beq ->invalid_access
+            // arg1: float -> int
+            | vcvt.s32.f32 s(vtmps2), s(reg1)
+            | vmov rtmp1, s(vtmps2)
+            // arg1: index += offset
+            | ldr rtmp2, <1
+            | add rtmp1, rtmp1, rtmp2
+            // arg1: index >= stack_count?
+            | ldr rtmp2, [rArg1, #(ctx_stack_count_offset)]
+            | cmp rtmp2, rtmp1
+            | bls ->invalid_access
+            // arg1: address = stack_address + index*sizeof(lmnt_value)
+            | lsl rtmp1, rtmp1, #((int)log2f(sizeof(lmnt_value)))
+            | add rtmp1, rtmp1, rStack
+            | vldr s(vtmps2), [rtmp1]
+
+            // arg3: float -> int
+            | vcvt.s32.f32 s(vtmps1), s(reg3)
+            | vmov rtmp1, s(vtmps1)
+            // arg3: index += offset
+            | ldr rtmp2, <1
+            | add rtmp1, rtmp1, rtmp2
+            // arg3: index >= stack_count?
+            | ldr rtmp2, [rArg1, #(ctx_stack_count_offset)]
+            | cmp rtmp2, rtmp1
+            | bls ->invalid_access
+            // arg3: address = stack_address + index*sizeof(lmnt_value)
+            | lsl rtmp1, rtmp1, #((int)log2f(sizeof(lmnt_value)))
+            | add rtmp1, rtmp1, rStack
+            | vstr s(vtmps2), [rtmp1]
+
+            // We could just have overwritten any of the stack we loaded into registers, so...
+            // This won't write anything since we were only reading
+            platformWriteAndEvictAll(state);
+            break;
+        }
 
         case LMNT_OP_EXTCALL:
             // keep these or not?

--- a/LMNT/src/lmnt/jit/jit-armv7m.dasc
+++ b/LMNT/src/lmnt/jit/jit-armv7m.dasc
@@ -803,10 +803,19 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | mov r0, #LMNT_OK
     | ->return:
     | epilogue, use_nv
-    fndata->buffer = targetLinkAndEncode(&state->dasm_state, &fndata->codesize);
-    dasm_free(&state->dasm_state);
-    // + 1 to indicate the function is THUMB not ARM
-    fndata->function = (lmnt_jit_fn)((intptr_t)labels[lbl_lmnt_main] + 1);
+    | ->invalid_access:
+    // can't use a negative immediate with mov
+    | mvn r0, #((-LMNT_ERROR_ACCESS_VIOLATION) - 1)
+    | b ->return
+
+    if (result == LMNT_OK) {
+        result = targetLinkAndEncode(&state->dasm_state, &fndata->buffer, &fndata->codesize);
+        if (result == LMNT_OK) {
+            // + 1 to indicate the function is THUMB not ARM
+            fndata->function = (lmnt_jit_fn)((intptr_t)labels[lbl_lmnt_main] + 1);
+        }
+        dasm_free(&state->dasm_state);
+    }
 
 #if defined(LMNT_JIT_COLLECT_STATS)
     if (stats)

--- a/LMNT/src/lmnt/jit/jit-armv7m.dasc
+++ b/LMNT/src/lmnt/jit/jit-armv7m.dasc
@@ -738,9 +738,7 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             break;
 
         case LMNT_OP_INDEXDIS:
-        case LMNT_OP_INDEXSSS:
-        case LMNT_OP_INDEXDSS:
-        case LMNT_OP_INDEXDSD:
+        case LMNT_OP_INDEXDID:
             // not up to these yet :(
             break;
 

--- a/LMNT/src/lmnt/jit/jit-x86_64.dasc
+++ b/LMNT/src/lmnt/jit/jit-x86_64.dasc
@@ -863,9 +863,14 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | ->invalid_access:
     | mov rax, LMNT_ERROR_ACCESS_VIOLATION
     | jmp ->return
-    fndata->buffer = targetLinkAndEncode(&state->dasm_state, &fndata->codesize);
-    dasm_free(&state->dasm_state);
-    fndata->function = (lmnt_jit_fn)labels[lbl_lmnt_main];
+
+    if (result == LMNT_OK) {
+        result = targetLinkAndEncode(&state->dasm_state, &fndata->buffer, &fndata->codesize);
+        if (result == LMNT_OK) {
+            fndata->function = (lmnt_jit_fn)labels[lbl_lmnt_main];
+        }
+        dasm_free(&state->dasm_state);
+    }
 
 #if defined(LMNT_JIT_COLLECT_STATS)
     if (stats)

--- a/LMNT/src/lmnt/jit/jit-x86_64.dasc
+++ b/LMNT/src/lmnt/jit/jit-x86_64.dasc
@@ -787,16 +787,57 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | writes_or_notify reg3, in.arg3, xmmtmp1
             break;
         }
-        case LMNT_OP_INDEXSSS:
+        case LMNT_OP_INDEXDID:
         {
-            break;
-        }
-        case LMNT_OP_INDEXDSS:
-        {
-            break;
-        }
-        case LMNT_OP_INDEXDSD:
-        {
+            // Unknown at compile-time what stack addresses this is going to read from OR WRITE TO. So...
+            platformWriteAndEvictAll(state);
+
+            const uint32_t offset = (uint32_t)in.arg2;
+            | .rodata
+            |1:
+            | .dword offset
+            | .code
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, xmmtmp2);
+            // arg1: check for NaN/infinities
+            | movd rdx, xmm(reg1)
+            | or edx, dword [->inftonanbits]
+            | and edx, dword [->nanbits]
+            | cmp edx, dword [->nanbits]
+            | je ->invalid_access
+            ||acquireScalarRegisterOrLoad(state, in.arg3, &reg3, ACCESSTYPE_READ, xmmtmp1);
+            // arg3: check for NaN/infinities
+            | movd rdx, xmm(reg3)
+            | or edx, dword [->inftonanbits]
+            | and edx, dword [->nanbits]
+            | cmp edx, dword [->nanbits]
+            | je ->invalid_access
+            // arg1: float -> int
+            | cvtss2si rdx, xmm(reg1)
+            // arg1: index += offset
+            | add edx, dword [<1]
+            // arg1: index >= stack_count?
+            | cmp rdx, qword [rArg1 + ctx_stack_count_offset]
+            | jae ->invalid_access
+            // arg1: address = stack_address + index*sizeof(lmnt_value)
+            | shl rdx, (int)log2f(sizeof(lmnt_value))
+            | add rdx, rStack
+            | movss xmm(xmmtmp2), dword [rdx]
+
+            // arg3: float -> int
+            | cvtss2si rdx, xmm(reg3)
+            // arg3: index += offset
+            | add edx, dword [<1]
+            // arg3: index >= stack_count?
+            | cmp rdx, qword [rArg1 + ctx_stack_count_offset]
+            | jae ->invalid_access
+            // arg3: address = stack_address + index*sizeof(lmnt_value)
+            | shl rdx, (int)log2f(sizeof(lmnt_value))
+            | add rdx, rStack
+            | movss dword [rdx], xmm(xmmtmp2)
+
+            // We could just have overwritten any of the stack we loaded into registers, so...
+            // This won't write anything since we were only reading
+            platformWriteAndEvictAll(state);
             break;
         }
 

--- a/LMNT/src/lmnt/jit/jit-x86_64.dasc
+++ b/LMNT/src/lmnt/jit/jit-x86_64.dasc
@@ -219,6 +219,7 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
 
     // store LMNT stack base
     const size_t ctx_stack_offset = offsetof(lmnt_ictx, stack);
+    const size_t ctx_stack_count_offset = offsetof(lmnt_ictx, cur_stack_count);
     | mov rStack, [rArg1 + ctx_stack_offset]
 
     lmnt_result result = LMNT_OK;
@@ -755,11 +756,49 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             break;
 
         case LMNT_OP_INDEXDIS:
-        case LMNT_OP_INDEXSSS:
-        case LMNT_OP_INDEXDSS:
-        case LMNT_OP_INDEXDSD:
-            // not up to these yet :(
+        {
+            // Unknown at compile-time what stack addresses this is going to read from. So...
+            flushAllRegisters(state);
+
+            const uint32_t offset = (uint32_t)in.arg2;
+            | .rodata
+            |1:
+            | .dword offset
+            | .code
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, xmmtmp2);
+            // Check for NaN/infinities
+            | movd rdx, xmm(reg1)
+            | or edx, dword [->inftonanbits]
+            | and edx, dword [->nanbits]
+            | cmp edx, dword [->nanbits]
+            | je ->invalid_access
+            // float -> int
+            | cvtss2si rdx, xmm(reg1)
+            // index += offset
+            | add edx, dword [<1]
+            // index >= stack_count?
+            | cmp rdx, qword [rArg1 + ctx_stack_count_offset]
+            | jae ->invalid_access
+            // address = stack_address + index*sizeof(lmnt_value)
+            | shl rdx, (int)log2f(sizeof(lmnt_value))
+            | add rdx, rStack
+            ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, xmmtmp1);
+            | movd xmm(reg3), dword [rdx]
+            | writes_or_notify reg3, in.arg3, xmmtmp1
             break;
+        }
+        case LMNT_OP_INDEXSSS:
+        {
+            break;
+        }
+        case LMNT_OP_INDEXDSS:
+        {
+            break;
+        }
+        case LMNT_OP_INDEXDSD:
+        {
+            break;
+        }
 
         case LMNT_OP_EXTCALL:
             // keep these or not?
@@ -779,6 +818,9 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | mov rax, LMNT_OK
     | ->return:
     | epilogue, use_nv
+    | ->invalid_access:
+    | mov rax, LMNT_ERROR_ACCESS_VIOLATION
+    | jmp ->return
     fndata->buffer = targetLinkAndEncode(&state->dasm_state, &fndata->codesize);
     dasm_free(&state->dasm_state);
     fndata->function = (lmnt_jit_fn)labels[lbl_lmnt_main];

--- a/LMNT/src/lmnt/jit/jit-x86_64.dasc
+++ b/LMNT/src/lmnt/jit/jit-x86_64.dasc
@@ -213,6 +213,7 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | .dword 0x7FC00000, 0x7FC00000, 0x7FC00000, 0x7FC00000
     | ->inftonanbits:
     | .dword 0x00400000, 0x00400000, 0x00400000, 0x00400000
+
     | .code
     | ->lmnt_main:
     | prologue, use_nv

--- a/LMNT/src/lmnt/jit/jithelpers.h
+++ b/LMNT/src/lmnt/jit/jithelpers.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "lmnt/config.h"
+#include "lmnt/jitconfig.h"
 #include "lmnt/interpreter.h"
 #include "lmnt/jit.h"
 #include "lmnt/jit/hosthelpers.h"
@@ -125,11 +126,12 @@ static int lookahead(jit_compile_state* state, lmnt_offset spos, size_t scount)
 
 static void* targetLinkAndEncode(dasm_State** d, size_t* sz)
 {
-    void* buf;
     dasm_link(d, sz);
-    buf = hostAllocMemory(*sz);
-    dasm_encode(d, buf);
-    hostProtectMemory(buf, *sz);
+    void* buf = LMNT_JIT_ALLOC_CFN_MEMORY(*sz);
+    if (buf) {
+        dasm_encode(d, buf);
+        LMNT_JIT_PROTECT_CFN_MEMORY(buf, *sz);
+    }
     return buf;
 }
 

--- a/LMNT/src/lmnt/jit/jithelpers.h
+++ b/LMNT/src/lmnt/jit/jithelpers.h
@@ -144,6 +144,7 @@ static inline size_t getRegisterCount(jit_compile_state* state, size_t reg);
 static inline bool isRegisterInitialised(jit_compile_state* state, size_t reg);
 static void initialiseRegister(jit_compile_state* state, size_t reg);
 static bool flushRegister(jit_compile_state* state, size_t reg);
+static void flushAllRegisters(jit_compile_state* state);
 static inline void notifyRegisterWritten(jit_compile_state* state, size_t reg, size_t writeSize);
 static void writeAndEvictRegister(jit_compile_state* state, size_t reg);
 static void writeAndEvictRegisters(jit_compile_state* state, size_t reg, size_t scount);

--- a/LMNT/src/lmnt/jit/reghelpers-arm-vfp.h
+++ b/LMNT/src/lmnt/jit/reghelpers-arm-vfp.h
@@ -263,6 +263,13 @@ static bool flushRegister(jit_compile_state* state, size_t reg)
     return false;
 }
 
+static inline void flushAllRegisters(jit_compile_state* state)
+{
+    for (size_t i = state->fpreg->start; i != state->fpreg->end; ++i) {
+        flushRegister(state, i);
+    }
+}
+
 static inline void notifyRegisterWritten(jit_compile_state* state, size_t reg, size_t writeSize)
 {
     assert(reg + writeSize <= FPREG_MAX);

--- a/LMNT/src/lmnt/jit/reghelpers-x86.h
+++ b/LMNT/src/lmnt/jit/reghelpers-x86.h
@@ -140,6 +140,7 @@ static bool flushRegister(jit_compile_state* state, size_t reg)
 {
     const lmnt_offset spos = state->fpreg->xmm[reg].stackpos;
     const size_t sz = state->fpreg->xmm[reg].count;
+    if (sz == 0) return false;
     assert(sz == 4 || sz == 1);
 
     // If not modified, we have nothing to do here
@@ -153,6 +154,13 @@ static bool flushRegister(jit_compile_state* state, size_t reg)
         return true;
     }
     return false;
+}
+
+static inline void flushAllRegisters(jit_compile_state* state)
+{
+    for (size_t i = state->fpreg->start; i != state->fpreg->end; ++i) {
+        flushRegister(state, i);
+    }
 }
 
 static inline void notifyRegisterWritten(jit_compile_state* state, size_t reg, size_t writeSize)

--- a/LMNT/src/lmnt/opcodes.c
+++ b/LMNT/src/lmnt/opcodes.c
@@ -55,9 +55,7 @@ LMNT_ATTR_FAST lmnt_op_fn lmnt_op_functions[LMNT_OP_END] = {
     lmnt_op_ceils,
     lmnt_op_ceilv,
     lmnt_op_indexdis,
-    lmnt_op_indexsss,
-    lmnt_op_indexdss,
-    lmnt_op_indexdsd,
+    lmnt_op_indexdid,
     lmnt_op_extcall,
 };
 
@@ -109,15 +107,11 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
     { "CEILS",     LMNT_OPERAND_STACK1,  LMNT_OPERAND_UNUSED,  LMNT_OPERAND_STACK1  },
     { "CEILV",     LMNT_OPERAND_STACK4,  LMNT_OPERAND_UNUSED,  LMNT_OPERAND_STACK4  },
     { "INDEXDIS",  LMNT_OPERAND_DYNAMIC, LMNT_OPERAND_IMM,     LMNT_OPERAND_STACK1  },
-    { "INDEXSSS",  LMNT_OPERAND_STACKN,  LMNT_OPERAND_STACK1,  LMNT_OPERAND_STACK1  },
-    { "INDEXDSS",  LMNT_OPERAND_DYNAMIC, LMNT_OPERAND_STACK1,  LMNT_OPERAND_STACK1  },
-    { "INDEXDSD",  LMNT_OPERAND_DYNAMIC, LMNT_OPERAND_STACK1,  LMNT_OPERAND_STACK1  },
+    { "INDEXDID",  LMNT_OPERAND_DYNAMIC, LMNT_OPERAND_IMM,     LMNT_OPERAND_DYNAMIC },
     { "EXTCALL",   LMNT_OPERAND_DEFPTR,  LMNT_OPERAND_DEFPTR,  LMNT_OPERAND_STACKN  },
 };
 
 lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END] = {
-    lmnt_op_interrupt,
-    lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,

--- a/LMNT/src/lmnt/ops_misc.c
+++ b/LMNT/src/lmnt/ops_misc.c
@@ -87,36 +87,35 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_assignibv(lmnt_ictx* ctx, lmnt_offset arg1, l
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdis(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    lmnt_offset arg1v = value_to_offset(ctx->stack[arg1]);
-    if (arg1v < 0 || arg1v + arg2 >= ctx->stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
+    size_t arg1v = value_to_size_t(ctx->stack[arg1]);
+    if (arg1v + arg2 >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3] = ctx->stack[arg1v + arg2];
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexsss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    lmnt_offset arg2v = value_to_offset(ctx->stack[arg2]);
-    if (arg2v < 0 || arg1 + arg2v >= ctx->stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
+    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
+    if (arg1 + arg2v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3] = ctx->stack[arg1 + arg2v];
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    lmnt_offset arg1v = value_to_offset(ctx->stack[arg1]);
-    lmnt_offset arg2v = value_to_offset(ctx->stack[arg2]);
-    if (arg1v < 0 || arg2v < 0 || arg1v + arg2v >= ctx->stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
+    size_t arg1v = value_to_size_t(ctx->stack[arg1]);
+    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
+    if (arg1v + arg2v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3] = ctx->stack[arg1v + arg2v];
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdsd(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    lmnt_offset arg1v = value_to_offset(ctx->stack[arg1]);
-    lmnt_offset arg2v = value_to_offset(ctx->stack[arg2]);
-    lmnt_offset arg3v = value_to_offset(ctx->stack[arg3]);
-    if (arg1v < 0 || arg2v < 0 || arg3v < 0) return LMNT_ERROR_ACCESS_VIOLATION;
-    if (arg1v + arg2v >= ctx->stack_count || arg3v >= ctx->stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
+    size_t arg1v = value_to_size_t(ctx->stack[arg1]);
+    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
+    size_t arg3v = value_to_size_t(ctx->stack[arg3]);
+    if (arg1v + arg2v >= ctx->cur_stack_count || arg3v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3v] = ctx->stack[arg1v + arg2v];
     return LMNT_OK;
 }

--- a/LMNT/src/lmnt/ops_misc.c
+++ b/LMNT/src/lmnt/ops_misc.c
@@ -87,6 +87,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_assignibv(lmnt_ictx* ctx, lmnt_offset arg1, l
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdis(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
+    if (isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1])) return LMNT_ERROR_ACCESS_VIOLATION;
     size_t arg1v = value_to_size_t(ctx->stack[arg1]);
     if (arg1v + arg2 >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3] = ctx->stack[arg1v + arg2];
@@ -95,6 +96,8 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_indexdis(lmnt_ictx* ctx, lmnt_offset arg1, lm
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexdid(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
+    if (isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1])) return LMNT_ERROR_ACCESS_VIOLATION;
+    if (isnan(ctx->stack[arg3]) || isinf(ctx->stack[arg3])) return LMNT_ERROR_ACCESS_VIOLATION;
     size_t arg1v = value_to_size_t(ctx->stack[arg1]);
     size_t arg3v = value_to_size_t(ctx->stack[arg3]);
     if (arg1v + arg2 >= ctx->cur_stack_count || arg3v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;

--- a/LMNT/src/lmnt/ops_misc.c
+++ b/LMNT/src/lmnt/ops_misc.c
@@ -93,30 +93,12 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_indexdis(lmnt_ictx* ctx, lmnt_offset arg1, lm
     return LMNT_OK;
 }
 
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexsss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
-{
-    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
-    if (arg1 + arg2v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
-    ctx->stack[arg3] = ctx->stack[arg1 + arg2v];
-    return LMNT_OK;
-}
-
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexdss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+LMNT_ATTR_FAST lmnt_result lmnt_op_indexdid(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
     size_t arg1v = value_to_size_t(ctx->stack[arg1]);
-    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
-    if (arg1v + arg2v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
-    ctx->stack[arg3] = ctx->stack[arg1v + arg2v];
-    return LMNT_OK;
-}
-
-LMNT_ATTR_FAST lmnt_result lmnt_op_indexdsd(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
-{
-    size_t arg1v = value_to_size_t(ctx->stack[arg1]);
-    size_t arg2v = value_to_size_t(ctx->stack[arg2]);
     size_t arg3v = value_to_size_t(ctx->stack[arg3]);
-    if (arg1v + arg2v >= ctx->cur_stack_count || arg3v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
-    ctx->stack[arg3v] = ctx->stack[arg1v + arg2v];
+    if (arg1v + arg2 >= ctx->cur_stack_count || arg3v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
+    ctx->stack[arg3v] = ctx->stack[arg1v + arg2];
     return LMNT_OK;
 }
 

--- a/LMNT/src/lmnt/ops_trig.c
+++ b/LMNT/src/lmnt/ops_trig.c
@@ -1,8 +1,8 @@
-#include "lmnt/ops_trig.h"
 #if defined(__GNUC__)
     #define _GNU_SOURCE
     #define USE_GNU_SINCOS
 #endif
+#include "lmnt/ops_trig.h"
 #include <math.h>
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_sin(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
@@ -50,7 +50,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_atan2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 LMNT_ATTR_FAST lmnt_result lmnt_op_sincos(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
 #if defined(USE_GNU_SINCOS)
-    sincos(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
+    sincosf(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
 #else
     ctx->stack[arg2] = sinf(ctx->stack[arg1]);
     ctx->stack[arg3] = cosf(ctx->stack[arg1]);

--- a/LMNT/src/lmnt/validation.c
+++ b/LMNT/src/lmnt/validation.c
@@ -132,23 +132,10 @@ static lmnt_validation_result validate_instruction(const lmnt_archive* archive, 
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
         LMNT_V_OK_OR_RETURN(validate_operand_stack_write(archive, def, arg3, arg2, constants_count, rw_stack_count));
         return LMNT_VALIDATION_OK;
-    case LMNT_OP_INDEXDSD:
+    case LMNT_OP_INDEXDID:
         // args are validated at runtime, but we can check stackrefs are valid
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg2, 1, constants_count, rw_stack_count));
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg3, 1, constants_count, rw_stack_count));
-        return LMNT_VALIDATION_OK;
-    case LMNT_OP_INDEXSSS:
-        // we can at least sanity-check the stack addresses and stackrefs
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 0, constants_count, rw_stack_count));
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg2, 1, constants_count, rw_stack_count));
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_write(archive, def, arg3, 0, constants_count, rw_stack_count));
-        return LMNT_VALIDATION_OK;
-    case LMNT_OP_INDEXDSS:
-        // we can at least sanity-check the stack addresses and stackrefs
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg2, 1, constants_count, rw_stack_count));
-        LMNT_V_OK_OR_RETURN(validate_operand_stack_write(archive, def, arg3, 0, constants_count, rw_stack_count));
         return LMNT_VALIDATION_OK;
     // stack, null, stack
     case LMNT_OP_ASSIGNSS:

--- a/LMNT/test/helpers.h
+++ b/LMNT/test/helpers.h
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 
 // Default: may be overridden by individual testsetup configs
-#define FLOAT_ERROR_MARGIN 0.00001
+#define FLOAT_ERROR_MARGIN 0.0001
 
 // Must be overridden by individual testsetup configs
 // Present here to avoid spurious Intellisense errors
@@ -44,7 +44,7 @@ typedef struct
 
 typedef struct test_function_data
 {
-    lmnt_def* def;
+    const lmnt_def* def;
     void* data;
 } test_function_data;
 

--- a/LMNT/test/test_misc.h
+++ b/LMNT/test/test_misc.h
@@ -331,7 +331,38 @@ static void test_assignibv(void)
 
 static void test_indexdis(void)
 {
-    // TODO: this, once implemented
+    archive a = create_archive_array("test", 1, 1, 2, 1, 4,
+        LMNT_OP_BYTES(LMNT_OP_INDEXDIS, 0x04, 0x00, 0x05),
+        350.0f, 700.0f, -100.0f, 50.0f
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 350.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -100.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 8.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
 static void test_indexsss(void)
@@ -363,10 +394,10 @@ MAKE_REGISTER_SUITE_FUNCTION(misc,
     CUNIT_CI_TEST(test_assigniis),
     CUNIT_CI_TEST(test_assignibs),
     CUNIT_CI_TEST(test_assigniiv),
-    CUNIT_CI_TEST(test_assignibv)
-    // CUNIT_CI_TEST(test_indexdis),
-    // CUNIT_CI_TEST(test_indexsss),
-    // CUNIT_CI_TEST(test_indexdss),
-    // CUNIT_CI_TEST(test_indexdsd),
+    CUNIT_CI_TEST(test_assignibv),
+    CUNIT_CI_TEST(test_indexdis),
+    CUNIT_CI_TEST(test_indexsss),
+    CUNIT_CI_TEST(test_indexdss),
+    CUNIT_CI_TEST(test_indexdsd)
     // CUNIT_CI_TEST(test_interrupt)
 );

--- a/LMNT/test/test_misc.h
+++ b/LMNT/test/test_misc.h
@@ -365,19 +365,58 @@ static void test_indexdis(void)
     TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
-static void test_indexsss(void)
+static void test_indexdid(void)
 {
-    // TODO: this, once implemented
-}
+    archive a = create_archive_array("test", 2, 1, 4, 1, 4,
+        LMNT_OP_BYTES(LMNT_OP_INDEXDID, 0x04, 0x00, 0x05),
+        350.0f, 700.0f, -100.0f, 50.0f
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
 
-static void test_indexdss(void)
-{
-    // TODO: this, once implemented
-}
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
 
-static void test_indexdsd(void)
-{
-    // TODO: this, once implemented
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 350.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.0f, 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -100.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -1.0f, 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 10.0f, 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, -6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, 16.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""), 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""), nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY, 6.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), LMNT_ERROR_ACCESS_VIOLATION);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
 static void test_interrupt(void)
@@ -396,8 +435,6 @@ MAKE_REGISTER_SUITE_FUNCTION(misc,
     CUNIT_CI_TEST(test_assigniiv),
     CUNIT_CI_TEST(test_assignibv),
     CUNIT_CI_TEST(test_indexdis),
-    CUNIT_CI_TEST(test_indexsss),
-    CUNIT_CI_TEST(test_indexdss),
-    CUNIT_CI_TEST(test_indexdsd)
+    CUNIT_CI_TEST(test_indexdid)
     // CUNIT_CI_TEST(test_interrupt)
 );

--- a/LMNT/test/test_misc.h
+++ b/LMNT/test/test_misc.h
@@ -419,11 +419,6 @@ static void test_indexdid(void)
     TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
-static void test_interrupt(void)
-{
-    // TODO: funky things with ucontext/SetThreadContext?
-}
-
 
 
 MAKE_REGISTER_SUITE_FUNCTION(misc,
@@ -436,5 +431,4 @@ MAKE_REGISTER_SUITE_FUNCTION(misc,
     CUNIT_CI_TEST(test_assignibv),
     CUNIT_CI_TEST(test_indexdis),
     CUNIT_CI_TEST(test_indexdid)
-    // CUNIT_CI_TEST(test_interrupt)
 );


### PR DESCRIPTION
- Reduces the number and complexity of dynamic indexing instructions
- Implements dynamic indexing instructions for JIT (x86_64 and ARMv7-M)
- Adds tests for dynamic indexing instructions
- Fixes several issues in the ARMv7-M JIT (rounding behaviour with NaNs, extern function calls)
- Changed behaviour of `ASSIGNIIx` instruction (now expects the immediate to be a signed int32 not unsigned)
- Fixes runtime checks for stack addresses so it caps at the stack count specified by this function, not the available memory space
- Actually checks that DynASM succeeded in encoding the function before trying to do things with it...