### PR TITLE
LMNT: logarithm instructions

### DIFF
--- a/LMNT/doc/Instructions.md
+++ b/LMNT/doc/Instructions.md
@@ -552,6 +552,59 @@ Performs a square root operation on each value in a 4-wide vector, and stores th
 ```
 
 
+## `LOG`
+Takes the logarithm of a value, also specifying the base, and writes the result.
+
+| Arg | Direction | Type       | Size   | Meaning                                |
+| --: | :-------- | :--------- | :----- | :------------------------------------- |
+| 1   | Input     | Stack Loc  | Scalar | Location of the logarithm input        |
+| 2   | Input     | Stack Loc  | Scalar | Location of the logarithm base         |
+| 3   | Output    | Stack Loc  | Scalar | Stack location to write result to      |
+
+```c
+    stack[arg3] = log(stack[arg1], stack[arg2])
+```
+
+
+## `LN`
+Takes the natural logarithm of an input value, and writes the result.
+
+| Arg | Direction | Type       | Size   | Meaning                                |
+| --: | :-------- | :--------- | :----- | :------------------------------------- |
+| 1   | Input     | Stack Loc  | Scalar | Location of the logarithm input        |
+| 3   | Output    | Stack Loc  | Scalar | Stack location to write result to      |
+
+```c
+    stack[arg3] = ln(stack[arg1])
+```
+
+
+## `LOG2`
+Takes the base-2 logarithm of an input value, and writes the result.
+
+| Arg | Direction | Type       | Size   | Meaning                                |
+| --: | :-------- | :--------- | :----- | :------------------------------------- |
+| 1   | Input     | Stack Loc  | Scalar | Location of the logarithm input        |
+| 3   | Output    | Stack Loc  | Scalar | Stack location to write result to      |
+
+```c
+    stack[arg3] = log2(stack[arg1])
+```
+
+
+## `LOG10`
+Takes the base-10 logarithm of an input value, and writes the result.
+
+| Arg | Direction | Type       | Size   | Meaning                                |
+| --: | :-------- | :--------- | :----- | :------------------------------------- |
+| 1   | Input     | Stack Loc  | Scalar | Location of the logarithm input        |
+| 3   | Output    | Stack Loc  | Scalar | Stack location to write result to      |
+
+```c
+    stack[arg3] = log10(stack[arg1])
+```
+
+
 ## `ABSS`
 Calculates the absolute value of a value and stores the result in another location.
 

--- a/LMNT/include/lmnt/opcodes.h
+++ b/LMNT/include/lmnt/opcodes.h
@@ -59,6 +59,12 @@ enum
     // sqrt: stack, null, stack
     LMNT_OP_SQRTS,
     LMNT_OP_SQRTV,
+    // log: stack, stack, stack
+    LMNT_OP_LOG,
+    // logn: stack, null, stack
+    LMNT_OP_LN,
+    LMNT_OP_LOG2,
+    LMNT_OP_LOG10,
     // abs: stack, null, stack
     LMNT_OP_ABSS,
     LMNT_OP_ABSV,

--- a/LMNT/include/lmnt/ops_math.h
+++ b/LMNT/include/lmnt/ops_math.h
@@ -27,6 +27,11 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_powvs(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 LMNT_ATTR_FAST lmnt_result lmnt_op_sqrts(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 LMNT_ATTR_FAST lmnt_result lmnt_op_sqrtv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
+LMNT_ATTR_FAST lmnt_result lmnt_op_log(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+LMNT_ATTR_FAST lmnt_result lmnt_op_ln(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+LMNT_ATTR_FAST lmnt_result lmnt_op_log2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+LMNT_ATTR_FAST lmnt_result lmnt_op_log10(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
 LMNT_ATTR_FAST lmnt_result lmnt_op_sumv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 #endif

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -715,6 +715,18 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         case LMNT_OP_ABSV:
             | mathv1serial vabs.f32
             break;
+        case LMNT_OP_LOG:
+            // TODO
+            break;
+        case LMNT_OP_LN:
+            | extern1 logf, 0, in.arg3, reg3
+            break;
+        case LMNT_OP_LOG2:
+            | extern1 log2f, 0, in.arg3, reg3
+            break;
+        case LMNT_OP_LOG10:
+            | extern1 log10f, 0, in.arg3, reg3
+            break;
 
         case LMNT_OP_SUMV:
             ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, vtmps1);

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -716,7 +716,29 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | mathv1serial vabs.f32
             break;
         case LMNT_OP_LOG:
-            // TODO
+            if (acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, 0)) {
+                | vmov.f32 s0, s(reg1)
+            }
+            platformWriteAndEvictVolatile(state);
+            |.rodata
+            |1:
+            | .long (intptr_t)(&logf)
+            |.code
+            | ldr r1, <1
+            | blx r1
+            | vpush {s0-s0}
+            | reads 0, in.arg2
+            | ldr r1, <1
+            | blx r1
+            | vpop {s1-s1}
+            if (acquireScalarRegister(state, in.arg3, &reg3, ACCESSTYPE_WRITE)) {
+                | vdiv.f32 s(reg3), s1, s0
+                notifyRegisterWritten(state, reg3, 1);
+            } else {
+                | vdiv.f32 s1, s1, s0
+                | writes in.arg3, 1
+            }
+            ||rmode = RMODE_UNKNOWN;
             break;
         case LMNT_OP_LN:
             | extern1 logf, 0, in.arg3, reg3

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -705,6 +705,19 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             }
             | writev_or_notify reg3, in.arg3, xmmtmp1
             break;
+        case LMNT_OP_LOG:
+            // TODO
+            break;
+        case LMNT_OP_LN:
+            | extern1 logf, 0, in.arg3, 0, reg3
+            break;
+        case LMNT_OP_LOG2:
+            | extern1 log2f, 0, in.arg3, 0, reg3
+            break;
+        case LMNT_OP_LOG10:
+            | extern1 log10f, 0, in.arg3, 0, reg3
+            break;
+
         case LMNT_OP_ABSS:
             ||acquireScalarRegisterOrDefault(state, in.arg3, &reg3, ACCESSTYPE_WRITE, xmmtmp1);
             if (acquireScalarRegister(state, in.arg1, &reg1, ACCESSTYPE_READ)) {

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -40,13 +40,18 @@
 |.endif
 
 | .define rStack, rbx
-| .define CFRAME_SPACE, aword * 6
 | .define xmmtmp1, 1
 | .define xmmtmp2, 0
 
 
 // If we use any of these non-volatile registers within *our* function
 // (NOT anything we call) then we must push/pop them here
+
+// IMPORTANT: if the amount of data pushed/popped is changed here, this
+// will affect the stack alignment of all external calls out to C.
+// On x86_64, at the time of a call, (rsp + 8) must be 16-byte aligned.
+// Change this number (ensuring it remains >= 5) to adjust the alignment.
+| .define CFRAME_SPACE, aword * 6
 
 | .macro prologue, use_nv
 ||#if defined(_WIN32)
@@ -706,7 +711,28 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | writev_or_notify reg3, in.arg3, xmmtmp1
             break;
         case LMNT_OP_LOG:
-            // TODO
+            if (acquireScalarRegister(state, in.arg1, &reg1, ACCESSTYPE_READ)) {
+                | movss xmm0, xmm(reg1)
+            } else {
+                | reads xmm0, in.arg1
+            }
+            platformWriteAndEvictVolatile(state);
+            | mov64 rax, (const intptr_t)(&logf)
+            | call rax
+            | sub rsp, 16  // remain 16-byte aligned for call to logf
+            | movss dword [rsp], xmm0
+            | reads xmm0, in.arg2
+            | mov64 rax, (const intptr_t)(&logf)
+            | call rax
+            | movss xmm1, dword [rsp]
+            | add rsp, 16
+            | divss xmm1, xmm0
+            if (acquireScalarRegister(state, in.arg3, &reg3, ACCESSTYPE_WRITE)) {
+                | movss xmm(reg3), xmm1
+                notifyRegisterWritten(state, reg3, 1);
+            } else {
+                | writes in.arg3, xmm1
+            }
             break;
         case LMNT_OP_LN:
             | extern1 logf, 0, in.arg3, 0, reg3

--- a/LMNT/src/opcodes.c
+++ b/LMNT/src/opcodes.c
@@ -46,6 +46,10 @@ LMNT_ATTR_FAST lmnt_op_fn lmnt_op_functions[LMNT_OP_END] = {
     lmnt_op_powvs,
     lmnt_op_sqrts,
     lmnt_op_sqrtv,
+    lmnt_op_log,
+    lmnt_op_ln,
+    lmnt_op_log2,
+    lmnt_op_log10,
     lmnt_op_abss,
     lmnt_op_absv,
     lmnt_op_sumv,
@@ -120,6 +124,10 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
     { "POWVS",     LMNT_OPERAND_STACK4,   LMNT_OPERAND_STACK1,   LMNT_OPERAND_STACK4   },
     { "SQRTS",     LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
     { "SQRTV",     LMNT_OPERAND_STACK4,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK4   },
+    { "LOG",       LMNT_OPERAND_STACK1,   LMNT_OPERAND_STACK1,   LMNT_OPERAND_STACK1   },
+    { "LN",        LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
+    { "LOG2",      LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
+    { "LOG10",     LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
     { "ABSS",      LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
     { "ABSV",      LMNT_OPERAND_STACK4,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK4   },
     { "SUMV",      LMNT_OPERAND_STACK4,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_STACK1   },
@@ -157,6 +165,10 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
 };
 
 lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END] = {
+    lmnt_op_interrupt,
+    lmnt_op_interrupt,
+    lmnt_op_interrupt,
+    lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,

--- a/LMNT/src/ops_math.c
+++ b/LMNT/src/ops_math.c
@@ -116,6 +116,30 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_sqrtv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
     return LMNT_OK;
 }
 
+LMNT_ATTR_FAST lmnt_result lmnt_op_log(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+{
+    ctx->stack[arg3] = logf(ctx->stack[arg1]) / logf(ctx->stack[arg2]);
+    return LMNT_OK;
+}
+
+LMNT_ATTR_FAST lmnt_result lmnt_op_ln(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+{
+    ctx->stack[arg3] = logf(ctx->stack[arg1]);
+    return LMNT_OK;
+}
+
+LMNT_ATTR_FAST lmnt_result lmnt_op_log2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+{
+    ctx->stack[arg3] = log2f(ctx->stack[arg1]);
+    return LMNT_OK;
+}
+
+LMNT_ATTR_FAST lmnt_result lmnt_op_log10(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+{
+    ctx->stack[arg3] = log10f(ctx->stack[arg1]);
+    return LMNT_OK;
+}
+
 LMNT_ATTR_FAST lmnt_result lmnt_op_sumv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
     ctx->stack[arg3] = ctx->stack[arg1 + 0] + ctx->stack[arg1 + 1] + ctx->stack[arg1 + 2] + ctx->stack[arg1 + 3];

--- a/LMNT/src/validation.c
+++ b/LMNT/src/validation.c
@@ -206,6 +206,7 @@ static lmnt_validation_result validate_instruction(const lmnt_archive* archive, 
     case LMNT_OP_DIVSS:
     case LMNT_OP_MODSS:
     case LMNT_OP_POWSS:
+    case LMNT_OP_LOG:
     case LMNT_OP_MINSS:
     case LMNT_OP_MAXSS:
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
@@ -239,6 +240,9 @@ static lmnt_validation_result validate_instruction(const lmnt_archive* archive, 
     case LMNT_OP_ACOS:
     case LMNT_OP_ATAN:
     case LMNT_OP_SQRTS:
+    case LMNT_OP_LN:
+    case LMNT_OP_LOG2:
+    case LMNT_OP_LOG10:
     case LMNT_OP_ABSS:
     case LMNT_OP_FLOORS:
     case LMNT_OP_ROUNDS:

--- a/LMNT/test/test_maths_scalar.h
+++ b/LMNT/test/test_maths_scalar.h
@@ -363,6 +363,246 @@ static void test_sqrts(void)
     TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
+static void test_log(void)
+{
+    archive a = create_archive_array("test", 2, 1, 3, 1, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_LOG, 0x00, 0x01, 0x02)
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 10.0f, 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 8.0f, 2.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 3.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.1f, 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f, 4.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.3f, 2.4f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.3637522592537794, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 725.0f, 3.4f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.381846607367086, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.0f, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
+
+    // NaN / inf
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, 5.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.0f, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && !signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""), 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""), nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY, 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && !signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY, 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_ln(void)
+{
+    archive a = create_archive_array("test", 1, 1, 2, 1, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_LN, 0x00, 0x00, 0x01)
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0986122886681098, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.718281828459045f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.5f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -0.6931471805599453, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 725.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 6.586171654854675, FLOAT_ERROR_MARGIN);
+
+    // NaN / inf
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && !signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_log2(void)
+{
+    archive a = create_archive_array("test", 1, 1, 2, 1, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_LOG2, 0x00, 0x00, 0x01)
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.584962500721156, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.718281828459045f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.4426950408889634, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.5f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 725.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 9.501837184902296, FLOAT_ERROR_MARGIN);
+
+    // NaN / inf
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && !signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_log10(void)
+{
+    archive a = create_archive_array("test", 1, 1, 2, 1, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_LOG10, 0x00, 0x00, 0x01)
+    );
+    test_function_data fndata;
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.47712125471966244, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 2.718281828459045f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.4342944819032518, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 10.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.5f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], -0.3010299956639812, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 725.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 2.8603380065709936, FLOAT_ERROR_MARGIN);
+
+    // NaN / inf
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isinf(rvals[0]) && !signbit(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
 
 
 MAKE_REGISTER_SUITE_FUNCTION(maths_scalar,
@@ -372,5 +612,9 @@ MAKE_REGISTER_SUITE_FUNCTION(maths_scalar,
     CUNIT_CI_TEST(test_divss),
     CUNIT_CI_TEST(test_modss),
     CUNIT_CI_TEST(test_powss),
-    CUNIT_CI_TEST(test_sqrts)
+    CUNIT_CI_TEST(test_sqrts),
+    CUNIT_CI_TEST(test_log),
+    CUNIT_CI_TEST(test_ln),
+    CUNIT_CI_TEST(test_log2),
+    CUNIT_CI_TEST(test_log10)
 );


### PR DESCRIPTION
Adds logarithm instructions to LMNT:

- `LOG`: logarithm using an arbitrary base
- `LN`: natural logarithm (base `e`)
- `LOG2`: log base 2
- `LOG10`: log base 10

JIT implementations just call through to C for now.