### PR TITLE
LMNT JIT: selective flushing of register cache

### DIFF
--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -307,6 +307,18 @@ static void platformWriteAndEvictVolatile(jit_compile_state* state)
         writeAndEvictRegister(state, i);
 }
 
+static void platformWriteAndEvictByStack(jit_compile_state* state, lmnt_offset start, lmnt_offset end)
+{
+    const reg_status* s = state->fpreg->s;
+    for (size_t i = state->fpreg->start; i < state->fpreg->end; ++i)
+    {
+        // if the first stackpos in this register is before the end of the requested block...
+        // and the end of this register's last stack element is after the start of the block...
+        if (s[i].stackpos < end && s[i].stackpos + s[i].count > start)
+            writeAndEvictRegister(state, i);
+    }
+}
+
 
 lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_jit_fn_data* fndata, lmnt_jit_compile_stats* stats)
 {
@@ -1148,7 +1160,11 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     }
 
     | ->ok_return:
-    platformWriteAndEvictAll(state);
+    // Ensure our return values or any updated constants are flushed to stack
+    const lmnt_offset constants_count = validated_get_constants_count(&ctx->archive);
+    const lmnt_offset rvals_start = constants_count + def->args_count;
+    platformWriteAndEvictByStack(state, 0, constants_count);
+    platformWriteAndEvictByStack(state, rvals_start, rvals_start + def->rvals_count);
     | mov r0, #LMNT_OK
     | ->return:
     | epilogue, use_nv

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -244,6 +244,18 @@ static void platformWriteAndEvictVolatile(jit_compile_state* state)
         writeAndEvictRegister(state, i);
 }
 
+static void platformWriteAndEvictByStack(jit_compile_state* state, lmnt_offset start, lmnt_offset end)
+{
+    const reg_status* xmm = state->fpreg->xmm;
+    for (size_t i = state->fpreg->start; i < state->fpreg->end; ++i)
+    {
+        // if the first stackpos in this register is before the end of the requested block...
+        // and the end of this register's last stack element is after the start of the block...
+        if (xmm[i].stackpos < end && xmm[i].stackpos + xmm[i].count > start)
+            writeAndEvictRegister(state, i);
+    }
+}
+
 
 
 lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_jit_fn_data* fndata, lmnt_jit_compile_stats* stats)
@@ -1135,7 +1147,11 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     }
 
     | ->ok_return:
-    platformWriteAndEvictAll(state);
+    // Ensure our return values or any updated constants are flushed to stack
+    const lmnt_offset constants_count = validated_get_constants_count(&ctx->archive);
+    const lmnt_offset rvals_start = constants_count + def->args_count;
+    platformWriteAndEvictByStack(state, 0, constants_count);
+    platformWriteAndEvictByStack(state, rvals_start, rvals_start + def->rvals_count);
     | mov rax, LMNT_OK
     | ->return:
     | epilogue, use_nv

--- a/LMNT/src/jit/jithelpers.h
+++ b/LMNT/src/jit/jithelpers.h
@@ -50,8 +50,8 @@ typedef enum
 } overlap_type;
 
 typedef unsigned int cpu_flags;
-struct jit_fpreg_data_s;
-typedef struct jit_fpreg_data_s jit_fpreg_data;
+struct jit_fpreg_data;
+typedef struct jit_fpreg_data jit_fpreg_data;
 
 typedef struct
 {

--- a/LMNT/src/jit/jithelpers.h
+++ b/LMNT/src/jit/jithelpers.h
@@ -71,6 +71,7 @@ typedef struct
 // prototypes for platform-specific functions implemented in dasc
 static void platformWriteAndEvictAll(jit_compile_state* state);
 static void platformWriteAndEvictVolatile(jit_compile_state* state);
+static void platformWriteAndEvictByStack(jit_compile_state* state, lmnt_offset start, lmnt_offset end);
 static void platformReadScalarToRegister(jit_compile_state* state, size_t reg, lmnt_offset stackpos);
 static void platformWriteScalarFromRegister(jit_compile_state* state, lmnt_offset stackpos, size_t reg);
 static void platformReadVectorToRegister(jit_compile_state* state, size_t reg, lmnt_offset stackpos);

--- a/LMNT/src/jit/reghelpers-arm-vfp.h
+++ b/LMNT/src/jit/reghelpers-arm-vfp.h
@@ -48,7 +48,7 @@ typedef struct
     size_t end;
 } fpreg_set;
 
-struct jit_fpreg_data_s
+struct jit_fpreg_data
 {
     size_t start;
     size_t end;

--- a/LMNT/src/jit/reghelpers-x86.h
+++ b/LMNT/src/jit/reghelpers-x86.h
@@ -41,7 +41,7 @@ typedef struct
     size_t end;
 } fpreg_set;
 
-struct jit_fpreg_data_s
+struct jit_fpreg_data
 {
     size_t start;
     size_t end;


### PR DESCRIPTION
Currently, on returning from a function we flush all registers in the cache (to ensure that any cached values are propagated to the function's stack before it returns).

However, this is not necessary: the user does not have access to all values on the stack, only the return values; thus, only these values (and persistent values in the `constants` table) need to be flushed - potentially saving numerous unnecessary instructions on every execution.