### PR TITLE
Element.NET - SF-473 - Incorrect port constraint identifier cause IdentifierNotFound for declaration

### DIFF
--- a/Element.NET/!1-AST/Declarations/ConstraintDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/ConstraintDeclaration.cs
@@ -5,7 +5,7 @@ namespace Element.AST
     public class IntrinsicConstraintDeclaration : Declaration
     {
         protected override string IntrinsicQualifier { get; } = "intrinsic";
-        protected override string Qualifier { get; } = "constraint";
+        protected override string Qualifier { get; } = "constraint ";
         protected override Type[] BodyAlternatives { get; } = {typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>
             IntrinsicImplementationCache.Get<IIntrinsicConstraintImplementation>(Identifier, context)
@@ -23,7 +23,7 @@ namespace Element.AST
     {
         protected override string IntrinsicQualifier { get; } = string.Empty;
 
-        protected override string Qualifier { get; } = "constraint";
+        protected override string Qualifier { get; } = "constraint ";
         protected override Type[] BodyAlternatives { get; } = {typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>
             PortList.ResolveInputConstraints(scope, context, false, false)

--- a/Element.NET/!1-AST/Declarations/ConstraintDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/ConstraintDeclaration.cs
@@ -4,7 +4,7 @@ namespace Element.AST
 {
     public class IntrinsicConstraintDeclaration : Declaration
     {
-        protected override string IntrinsicQualifier { get; } = "intrinsic";
+        protected override string IntrinsicQualifier { get; } = "intrinsic ";
         protected override string Qualifier { get; } = "constraint ";
         protected override Type[] BodyAlternatives { get; } = {typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>

--- a/Element.NET/!1-AST/Declarations/FunctionDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/FunctionDeclaration.cs
@@ -6,8 +6,8 @@ namespace Element.AST
 {
     public sealed class IntrinsicFunctionDeclaration : Declaration
     {
-        protected override string IntrinsicQualifier => "intrinsic";
-        protected override string Qualifier => "function";
+        protected override string IntrinsicQualifier => "intrinsic ";
+        protected override string Qualifier => "function ";
         protected override Type[] BodyAlternatives { get; } = {typeof(Nothing)};
 
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>

--- a/Element.NET/!1-AST/Declarations/NamespaceDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/NamespaceDeclaration.cs
@@ -6,7 +6,7 @@ namespace Element.AST
     public class NamespaceDeclaration : Declaration
     {
         protected override string IntrinsicQualifier => string.Empty;
-        protected override string Qualifier { get; } = "namespace";
+        protected override string Qualifier { get; } = "namespace ";
         protected override Type[] BodyAlternatives { get; } = {typeof(NamespaceBlock)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) => Namespace.Create(((NamespaceBlock) Body), scope, context);
         protected override void ValidateDeclaration(ResultBuilder builder, Context context)

--- a/Element.NET/!1-AST/Declarations/StructDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/StructDeclaration.cs
@@ -6,7 +6,7 @@ namespace Element.AST
     public class IntrinsicStructDeclaration : Declaration
     {
         protected override string IntrinsicQualifier { get; } = "intrinsic";
-        protected override string Qualifier { get; } = "struct";
+        protected override string Qualifier { get; } = "struct ";
         protected override Type[] BodyAlternatives { get; } = {typeof(StructBlock), typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>
             IntrinsicImplementationCache.Get<IIntrinsicStructImplementation>(Identifier, context)
@@ -48,7 +48,7 @@ namespace Element.AST
     public class CustomStructDeclaration : Declaration
     {
         protected override string IntrinsicQualifier { get; } = string.Empty;
-        protected override string Qualifier { get; } = "struct";
+        protected override string Qualifier { get; } = "struct ";
         protected override Type[] BodyAlternatives { get; } = {typeof(StructBlock), typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>
             PortList.ResolveInputConstraints(scope, context, false, false)

--- a/Element.NET/!1-AST/Declarations/StructDeclaration.cs
+++ b/Element.NET/!1-AST/Declarations/StructDeclaration.cs
@@ -5,7 +5,7 @@ namespace Element.AST
 {
     public class IntrinsicStructDeclaration : Declaration
     {
-        protected override string IntrinsicQualifier { get; } = "intrinsic";
+        protected override string IntrinsicQualifier { get; } = "intrinsic ";
         protected override string Qualifier { get; } = "struct ";
         protected override Type[] BodyAlternatives { get; } = {typeof(StructBlock), typeof(Nothing)};
         protected override Result<IValue> ResolveImpl(IScope scope, Context context) =>

--- a/Element.NET/!2-ValueObjectModel/Intrinsics/Functions/If.cs
+++ b/Element.NET/!2-ValueObjectModel/Intrinsics/Functions/If.cs
@@ -23,12 +23,9 @@ namespace Element.AST
                 .Accumulate(() => context.RootScope.Lookup(NumStruct.Instance.Identifier, context))
                 // ReSharper disable once PossibleUnintendedReferenceComparison
                 .Bind(t =>
-                {
-                    var (optionListIndexer, numStruct) = t;
-                    // Change condition to a numerical index for the list
-                    return numStruct.Call(new[] {arguments[0]}, context)
-                                    .CastInner<Instruction>()
-                                    .Bind(index => optionListIndexer.Call(new [] {index}, context));
-                });
+                          // Change condition to a numerical index for the list
+                          t.Item2.Call(new[] {arguments[0]}, context)
+                           .CastInner<Instruction>()
+                           .Bind(index => t.Item1.Call(new[] {index}, context)));
     }
 }

--- a/Element.NET/!2-ValueObjectModel/Intrinsics/Functions/List.cs
+++ b/Element.NET/!2-ValueObjectModel/Intrinsics/Functions/List.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords-pass.ele
@@ -1,0 +1,2 @@
+constraintBlah = 5
+structFoo = 10

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords-pass.ele
@@ -1,2 +1,0 @@
-constraintBlah = 5
-structFoo = 10

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Constraint-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Constraint-pass.ele
@@ -1,0 +1,1 @@
+constraintBlah = 5

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Function-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Function-pass.ele
@@ -1,0 +1,1 @@
+functionBleh = 5

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Intrinsic-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Intrinsic-pass.ele
@@ -1,0 +1,1 @@
+intrinsicBaz = 5

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicConstraint-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicConstraint-pass.ele
@@ -1,0 +1,1 @@
+intrinsic constraint constraintblah

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicFunction-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicFunction-pass.ele
@@ -1,0 +1,1 @@
+intrinsic function functionblah

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicStruct-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/IntrinsicStruct-pass.ele
@@ -1,0 +1,1 @@
+intrinsic struct structfoo

--- a/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Struct-pass.ele
+++ b/Laboratory/Tests/L0-Parsing/Declarations/Identifiers/IdentifiersStartingWithKeywords/Struct-pass.ele
@@ -1,0 +1,1 @@
+structFoo = 5

--- a/Laboratory/Tests/L2-Semantics/_1_UntypedFunctions.cs
+++ b/Laboratory/Tests/L2-Semantics/_1_UntypedFunctions.cs
@@ -32,7 +32,7 @@ namespace Laboratory.Tests.L2.Semantics
         [Test]
         public void RecursionIndirectDisallowed() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.RecursionNotAllowed, "recurseIndirect(5)");
         [Test]
-        public void SelfReferencingLocalWithOuter() => AssertApproxEqual(CompilerInput, "selfReferencingLocalWithOuter", "3.14");
+        public void SelfReferencingLocalWithOuter() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.RecursionNotAllowed, "selfReferencingLocalWithOuter");
         [Test]
         public void SelfReferencingLocal() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.RecursionNotAllowed, "selfReferencingLocal");
         
@@ -49,5 +49,8 @@ namespace Laboratory.Tests.L2.Semantics
         [TestCase("5(10)")]
         [TestCase("pi(2)")]
         public void CallNonFunction(string expression) => EvaluateExpectingElementError(CompilerInput, EleMessageCode.NotFunction, expression);
+        
+        [Test]
+        public void LookupError() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.IdentifierNotFound, "funcWithLookupError");
     }
 }

--- a/Laboratory/Tests/L2-Semantics/_1_UntypedFunctions.ele
+++ b/Laboratory/Tests/L2-Semantics/_1_UntypedFunctions.ele
@@ -27,3 +27,11 @@ selfReferencingLocal
     loc = loc
     return = loc
 }
+
+# This shouldn't be found by return in funcWithLookupError!
+myId = 10
+funcWithLookupError
+{
+    myId = add(lookupError, 5)
+    return = myId
+}

--- a/Laboratory/Tests/L2-Semantics/_2_TypedFunctions.cs
+++ b/Laboratory/Tests/L2-Semantics/_2_TypedFunctions.cs
@@ -64,5 +64,8 @@ namespace Laboratory.Tests.L2.Semantics
 
         [TestCase("Any(20)")]
         public void CallNonFunction(string expression) => EvaluateExpectingElementError(CompilerInput, EleMessageCode.NotFunction, expression);
+
+        [Test]
+        public void ConstraintLookupError() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.IdentifierNotFound, "constraintLookupError");
     }
 }

--- a/Laboratory/Tests/L2-Semantics/_2_TypedFunctions.ele
+++ b/Laboratory/Tests/L2-Semantics/_2_TypedFunctions.ele
@@ -18,3 +18,5 @@ addFive(a:Num):Num = add(a, 5)
 
 literalNumNotAConstraint(a:5):10 = a
 literalFunctionNotAConstraint(a:onlyNum):returnsNum = a
+
+constraintLookupError(a:ConstraintThatDoesntExist) = a

--- a/Laboratory/Tests/L2-Semantics/_3_IndexingNamespace.ele
+++ b/Laboratory/Tests/L2-Semantics/_3_IndexingNamespace.ele
@@ -45,4 +45,4 @@ namespace X
     }
 }
 
-makeAnonymousBlock(a, b) = { a = a, b = b }
+makeAnonymousBlock(_a, _b) = { a = _a, b = _b }

--- a/Laboratory/Tests/L2-Semantics/_6_NestedConstructs.cs
+++ b/Laboratory/Tests/L2-Semantics/_6_NestedConstructs.cs
@@ -1,3 +1,4 @@
+using Element;
 using NUnit.Framework;
 
 namespace Laboratory.Tests.L2.Semantics
@@ -41,5 +42,10 @@ namespace Laboratory.Tests.L2.Semantics
         
         [Test]
         public void NestedNamespacesInStructBody() => AssertTypeof(CompilerInput, "rootStruct.nestedNamespace", "Namespace");
+
+        [Test]
+        public void LocalFunctionConstraintNotFound() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.IdentifierNotFound, "localFuncWithConstraintError");
+        [Test]
+        public void LocalFunctionConstraintNotFoundDoesntContinueLookup() => EvaluateExpectingElementError(CompilerInput, EleMessageCode.IdentifierNotFound, "localFuncWithErrorThatShadowsOuterId");
     }
 }

--- a/Laboratory/Tests/L2-Semantics/_6_NestedConstructs.ele
+++ b/Laboratory/Tests/L2-Semantics/_6_NestedConstructs.ele
@@ -104,3 +104,16 @@ struct rootStruct(a:Num)
         a = 5
     }
 }
+
+localFuncWithConstraintError
+{
+    localFn(a:ConstraintThatDoesntExist) = a
+    return = localFn(5)
+}
+
+localFnThatShadows = 10
+localFuncWithErrorThatShadowsOuterId
+{
+    localFnThatShadows(a:ConstraintThatDoesntExist) = a
+    return = localFnThatShadows(5)
+}


### PR DESCRIPTION
- Add tests to cover lookup recursing when finding an error when it
shouldnt
- Fix bug where lookup recurses when finding an error instead of
returning the error
- Fix bug where identifiers starting with a keyword would
cause parse error e.g. constraintBlah
- Fix bug where blocks resolved with captures did not include the
captures in their member list (i.e. function calls)