### PR TITLE
libelement: undo setting nullptr to wrapped contents on deletion

### DIFF
--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -177,7 +177,6 @@ void element_declaration_delete(element_declaration** declaration)
     if (!declaration)
         return;
 
-    (*declaration)->decl = nullptr;
     delete *declaration;
     *declaration = nullptr;
 }
@@ -187,7 +186,6 @@ void element_instruction_delete(element_instruction** instruction)
     if (!instruction)
         return;
 
-    (*instruction)->instruction = nullptr;
     delete *instruction;
     *instruction = nullptr;
 }

--- a/libelement/src/object.cpp
+++ b/libelement/src/object.cpp
@@ -19,10 +19,8 @@ void element_object_delete(element_object** object)
     if (!object)
         return;
 
-    (*object)->obj = nullptr;
     delete *object;
     *object = nullptr;
-    return;
 }
 
 element_result element_object_model_ctx_create(element_interpreter_ctx* interpreter, element_object_model_ctx** output)
@@ -44,7 +42,6 @@ void element_object_model_ctx_delete(element_object_model_ctx** context)
     if (!context)
         return;
 
-    (*context)->ctx = nullptr;
     delete *context;
     *context = nullptr;
 }


### PR DESCRIPTION
could cause a nullptr deref if the user passes a valid pointer to a nullptr