### PR TITLE
libelement: Fix bug in for

### DIFF
--- a/Laboratory/Tests/L3-Prelude/For.cs
+++ b/Laboratory/Tests/L3-Prelude/For.cs
@@ -41,6 +41,10 @@ namespace Laboratory.Tests.L3.Prelude
         [DatapointSource]
         public (string FunctionExpression, string CallExpression, string ExpectedExpression)[] LoopFunctionCalls =
         {
+            ("factorial", "(1)", "1"),
+            ("factorial", "(2)", "2"),
+            ("factorial", "(3)", "6"),
+            ("factorial", "(4)", "24"),
             ("factorial", "(5)", "120"),
             ("NestedForLoop", "(0)", "200"),
             ("iterateWithMyStruct", "(5)", "7"),

--- a/libelement/src/instruction_tree/evaluator.cpp
+++ b/libelement/src/instruction_tree/evaluator.cpp
@@ -320,7 +320,12 @@ std::vector<element_value> element_evaluate_for(evaluator_ctx& context, const el
 
     while (predicate_value > 0) //predicate returned true
     {
-        result = do_evaluate(context, body, inputs.data(), value_size, intermediate_written);
+        // Create a buffer for outputs, so that we do not modify 'inputs' during the evaluation
+        // of the body.
+        std::vector<element_value> body_output_buffer(value_size);
+        result = do_evaluate(context, body, body_output_buffer.data(), value_size, intermediate_written);
+        std::move(body_output_buffer.begin(), body_output_buffer.end(), inputs.begin());
+
         if (result != ELEMENT_OK)
             throw;
 

--- a/libelement/src/instruction_tree/evaluator.cpp
+++ b/libelement/src/instruction_tree/evaluator.cpp
@@ -325,7 +325,9 @@ std::vector<element_value> element_evaluate_for(evaluator_ctx& context, const el
     while (predicate_value > 0) //predicate returned true
     {
         result = do_evaluate(context, body, body_output_buffer.data(), value_size, intermediate_written);
-        std::move(body_output_buffer.begin(), body_output_buffer.end(), inputs.begin());
+
+        std::swap(body_output_buffer, inputs);
+        context.boundaries.back().inputs = inputs.data();
 
         if (result != ELEMENT_OK)
             throw;

--- a/libelement/src/instruction_tree/evaluator.cpp
+++ b/libelement/src/instruction_tree/evaluator.cpp
@@ -318,11 +318,12 @@ std::vector<element_value> element_evaluate_for(evaluator_ctx& context, const el
     if (result != ELEMENT_OK)
         throw;
 
+    // Create a buffer for outputs, so that we do not modify 'inputs' during the evaluation
+    // of the body.
+    std::vector<element_value> body_output_buffer(value_size);
+
     while (predicate_value > 0) //predicate returned true
     {
-        // Create a buffer for outputs, so that we do not modify 'inputs' during the evaluation
-        // of the body.
-        std::vector<element_value> body_output_buffer(value_size);
         result = do_evaluate(context, body, body_output_buffer.data(), value_size, intermediate_written);
         std::move(body_output_buffer.begin(), body_output_buffer.end(), inputs.begin());
 


### PR DESCRIPTION
The bug was that the outputs from do_evaluate were pointers
to the context which it was using to perform calculations.