### PR TITLE
libelement: Fix potential bad bool comparison, and reuse bool conversion everywhere

### DIFF
--- a/libelement/src/instruction_tree/evaluator.cpp
+++ b/libelement/src/instruction_tree/evaluator.cpp
@@ -5,6 +5,8 @@
 #include <cassert>
 #include <cmath>
 
+using namespace element;
+
 struct evaluator_ctx
 {
     struct boundary
@@ -266,9 +268,9 @@ element_value element_evaluate_binary(element::instruction_binary::op op, elemen
 
     //boolean
     case element::instruction_binary::op::and_:
-        return a && b;
+        return to_bool(a) && to_bool(b);
     case element::instruction_binary::op::or_:
-        return a || b;
+        return to_bool(a) || to_bool(b);
 
     //comparison
     case element::instruction_binary::op::eq:
@@ -292,8 +294,7 @@ element_value element_evaluate_binary(element::instruction_binary::op op, elemen
 //TODO: Needs to be handled via list with dynamic indexing, this will be insufficient for when we have user input
 element_value element_evaluate_if(element_value predicate, element_value if_true, element_value if_false)
 {
-    //Element treats negative numbers and 0 as false
-    return predicate > 0 ? if_true : if_false;
+    return to_bool(predicate) ? if_true : if_false;
 }
 
 std::vector<element_value> element_evaluate_for(evaluator_ctx& context, const element::instruction_const_shared_ptr& initial, const element::instruction_const_shared_ptr& condition, const element::instruction_const_shared_ptr& body)
@@ -322,7 +323,7 @@ std::vector<element_value> element_evaluate_for(evaluator_ctx& context, const el
     // of the body.
     std::vector<element_value> body_output_buffer(value_size);
 
-    while (predicate_value > 0) //predicate returned true
+    while (to_bool(predicate_value)) //predicate returned true
     {
         result = do_evaluate(context, body, body_output_buffer.data(), value_size, intermediate_written);
 

--- a/libelement/src/instruction_tree/instructions.hpp
+++ b/libelement/src/instruction_tree/instructions.hpp
@@ -15,6 +15,13 @@
 
 namespace element
 {
+    //Element treats negative numbers and 0 as false
+    //todo: update to handle NAN's, once we've decided if they're truthy or falsy
+    [[nodiscard]] constexpr static bool to_bool(element_value value)
+    {
+        return value > element_value{ 0 };
+    }
+
     struct instruction : object, rtti_type<instruction>, std::enable_shared_from_this<instruction>
     {
     public:
@@ -86,7 +93,7 @@ namespace element
         [[nodiscard]] std::string to_string() const override
         {
             if (actual_type == type::boolean.get())
-                return m_value > 0 ? "true" : "false";
+                return to_bool(m_value) ? "true" : "false";
 
             return fmt::format("{:g}", m_value);
         }

--- a/libelement/src/object_model/intrinsics/intrinsic_for.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_for.cpp
@@ -51,7 +51,7 @@ object_const_shared_ptr compile_time_for(const object_const_shared_ptr& initial_
             return false;
         }
 
-        return ret_as_constant->value() > 0;
+        return to_bool(ret_as_constant->value());
     };
 
     const auto next_successor = [&initial_object, &body_function, &context, &source_info](const std::vector<object_const_shared_ptr>& input) -> object_const_shared_ptr {


### PR DESCRIPTION
Fixed a potential bug that andy spotted where we were comparing floats as if they were bool (hoping they had already gone through the bool conversion)

Standardised the use of it everywhere that we were doing bool conversions, which will be helpful later once it's specialised for nans as well

unit tests are unchanged (6 unrelated failing tests)