### PR TITLE
Libelement/feature/performance

### DIFF
--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -65,7 +65,7 @@ namespace libelement::cli
             result = context->expression_to_object(nullptr, expression.c_str(), &expression_object);
             if (result != ELEMENT_OK)
             {
-                context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+                context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
                 return compiler_message(error_conversion(result),
                                         "Failed to convert expression to object: " + expression + " called with " + custom_arguments.arguments + " at compile-time with element_result " + std::to_string(result),
                                         compilation_input.get_log_json());
@@ -79,7 +79,7 @@ namespace libelement::cli
 
                 if (result != ELEMENT_OK)
                 {
-                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
                     return compiler_message(error_conversion(result),
                                             "Failed to convert call expression to objects: " + expression + " called with " + custom_arguments.arguments + " at compile-time with element_result " + std::to_string(result),
                                             compilation_input.get_log_json());
@@ -100,7 +100,7 @@ namespace libelement::cli
 
                 if (result != ELEMENT_OK)
                 {
-                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
                     return compiler_message(error_conversion(result),
                                             "Failed to call object with arguments: " + expression + " called with " + custom_arguments.arguments + " at compile-time with element_result " + std::to_string(result),
                                             compilation_input.get_log_json());
@@ -111,7 +111,7 @@ namespace libelement::cli
                 result = element_object_simplify(expression_object, compilation_context, &result_object);
                 if (result != ELEMENT_OK)
                 {
-                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+                    context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
                     return compiler_message(error_conversion(result),
                                             "Failed to compile object: " + expression + " at compile-time with element_result " + std::to_string(result),
                                             compilation_input.get_log_json());
@@ -122,7 +122,7 @@ namespace libelement::cli
             result = element_object_to_instruction(result_object, &result_instruction);
             if (result != ELEMENT_OK)
             {
-                context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+                context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
                 return compiler_message(error_conversion(result),
                                         "Failed to convert object to instruction: " + expression + " called with " + custom_arguments.arguments + " at compile-time with element_result " + std::to_string(result),
                                         compilation_input.get_log_json());
@@ -139,7 +139,7 @@ namespace libelement::cli
             output.count = max_output_size;
             result = element_interpreter_evaluate_instruction(context, nullptr, result_instruction, &input, &output);
 
-            context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" });
+            context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
 
             if (result != ELEMENT_OK)
             {

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -184,6 +184,8 @@ set(element_sources
     "src/object_model/port.hpp"
     "src/object_model/scope.cpp"
     "src/object_model/scope.hpp"
+    "src/object_model/scope_caches.cpp"
+    "src/object_model/scope_caches.hpp"
     "src/object_model/type_annotation.cpp"
     "src/object_model/type_annotation.hpp"
 

--- a/libelement/src/instruction_tree/evaluator.cpp
+++ b/libelement/src/instruction_tree/evaluator.cpp
@@ -155,25 +155,25 @@ static element_result do_evaluate(evaluator_ctx& context, const element::instruc
 
 element_result element_evaluate(
     element_interpreter_ctx& context,
-    element::instruction_const_shared_ptr fn,
+    const element::instruction_const_shared_ptr& fn,
     const std::vector<element_value>& inputs,
     std::vector<element_value>& outputs,
     const element_evaluator_options opts)
 {
     auto size = outputs.size();
-    auto result = element_evaluate(context, std::move(fn), inputs.data(), inputs.size(), outputs.data(), size, std::move(opts));
+    auto result = element_evaluate(context, fn, inputs.data(), inputs.size(), outputs.data(), size, opts);
     outputs.resize(size);
-    return std::move(result);
+    return result;
 }
 
 element_result element_evaluate(
     element_interpreter_ctx& context,
-    element::instruction_const_shared_ptr fn,
+    const element::instruction_const_shared_ptr& fn,
     const element_value* inputs, size_t inputs_count,
     element_value* outputs, size_t& outputs_count,
     element_evaluator_options opts)
 {
-    evaluator_ctx ectx = { {}, std::move(opts) };
+    evaluator_ctx ectx = { {}, opts };
     ectx.boundaries.push_back({ inputs, inputs_count });
 
     size_t outputs_written = 0;

--- a/libelement/src/instruction_tree/evaluator.hpp
+++ b/libelement/src/instruction_tree/evaluator.hpp
@@ -9,14 +9,14 @@
 struct evaluator_ctx;
 element_result element_evaluate(
     element_interpreter_ctx& context,
-    element::instruction_const_shared_ptr fn,
+    const element::instruction_const_shared_ptr& fn,
     const std::vector<element_value>& inputs,
     std::vector<element_value>& outputs,
     element_evaluator_options opts);
 
 element_result element_evaluate(
     element_interpreter_ctx& context,
-    element::instruction_const_shared_ptr fn,
+    const element::instruction_const_shared_ptr& fn,
     const element_value* inputs, size_t inputs_count,
     element_value* outputs, size_t& outputs_count,
     element_evaluator_options opts);

--- a/libelement/src/instruction_tree/instructions.cpp
+++ b/libelement/src/instruction_tree/instructions.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<const object> instruction::index(
     }
 
     //find the declaration of the type that we are
-    const auto* const actual_type_decl = context.get_global_scope()->find(actual_type->get_identifier(), false);
+    const auto* const actual_type_decl = context.get_global_scope()->find(actual_type->get_identifier(), context.interpreter->caches, false);
     if (!actual_type_decl)
     {
         //TODO: Handle as error

--- a/libelement/src/interpreter_internal.cpp
+++ b/libelement/src/interpreter_internal.cpp
@@ -463,7 +463,7 @@ element_result element_interpreter_ctx::expression_to_object(
     parser.root->nearest_token = &tokeniser->tokens[0];
     element::assign_source_information(this, dummy_declaration, parser.root);
     auto expression_chain = build_expression_chain(this, parser.root->children[0].get(), dummy_declaration.get(), result);
-    dummy_declaration->body = std::move(expression_chain);
+    dummy_declaration->set_body(std::move(expression_chain));
 
     root.children.clear();
 

--- a/libelement/src/interpreter_internal.cpp
+++ b/libelement/src/interpreter_internal.cpp
@@ -473,14 +473,14 @@ element_result element_interpreter_ctx::expression_to_object(
         return result;
     }
 
-    bool success = global_scope->add_declaration(std::move(dummy_declaration));
+    bool success = global_scope->add_declaration(std::move(dummy_declaration), caches);
     if (!success)
     {
         (*object)->obj = nullptr;
         return ELEMENT_ERROR_UNKNOWN;
     }
 
-    const auto* found_dummy_decl = global_scope->find(dummy_identifier, false);
+    const auto* found_dummy_decl = global_scope->find(dummy_identifier, caches, false);
     assert(found_dummy_decl);
     auto compiled = found_dummy_decl->compile(compilation_context, found_dummy_decl->source_info);
 

--- a/libelement/src/interpreter_internal.hpp
+++ b/libelement/src/interpreter_internal.hpp
@@ -10,6 +10,7 @@
 #include "element/interpreter.h"
 #include "common_internal.hpp"
 #include "object_model/scope.hpp"
+#include "object_model/scope_caches.hpp"
 
 struct element_declaration
 {
@@ -78,4 +79,6 @@ public:
     std::shared_ptr<element_log_ctx> logger;
     std::shared_ptr<element::source_context> src_context;
     std::unique_ptr<element::scope> global_scope;
+
+    mutable element::scope_caches caches;
 };

--- a/libelement/src/object_model/call_stack.cpp
+++ b/libelement/src/object_model/call_stack.cpp
@@ -13,7 +13,7 @@ using namespace element;
 
 call_stack::call_stack()
 {
-    frames.reserve(100);
+    frames.reserve(reasonable_function_call_limit);
 }
 
 call_stack::frame& call_stack::push(std::shared_ptr<const function_instance> function, std::vector<object_const_shared_ptr> compiled_arguments)

--- a/libelement/src/object_model/call_stack.cpp
+++ b/libelement/src/object_model/call_stack.cpp
@@ -4,7 +4,7 @@
 #include <fmt/format.h>
 
 //SELF
-#include "declarations/declaration.hpp"
+#include "declarations/function_declaration.hpp"
 #include "intermediaries/function_instance.hpp"
 #include "compilation_context.hpp"
 #include "error_map.hpp"

--- a/libelement/src/object_model/call_stack.cpp
+++ b/libelement/src/object_model/call_stack.cpp
@@ -11,6 +11,11 @@
 
 using namespace element;
 
+call_stack::call_stack()
+{
+    frames.reserve(100);
+}
+
 call_stack::frame& call_stack::push(std::shared_ptr<const function_instance> function, std::vector<object_const_shared_ptr> compiled_arguments)
 {
     return frames.emplace_back(frame{ std::move(function), std::move(compiled_arguments) });
@@ -21,24 +26,25 @@ void call_stack::pop()
     frames.pop_back();
 }
 
-unsigned int call_stack::recursive_calls(std::shared_ptr<const function_instance> function) const
+unsigned int call_stack::recursive_calls(const function_instance* function) const
 {
     auto count = 0;
 
+    const bool check_recursion = !function->declarer->is_intrinsic();
+    if (!check_recursion)
+        return count;
+
     for (auto it = frames.rbegin(); it != frames.rend(); ++it)
     {
-        if (it->function->declarer == function->declarer
-            && it->function->declarer->recursive_handler(*this, function->declarer, it))
-        {
+        if (it->function->declarer == function->declarer)
             count++;
-        }
     }
 
     return count;
 }
 
 std::shared_ptr<error> call_stack::build_recursive_error(
-    std::shared_ptr<const function_instance> function,
+    const function_instance* function,
     const compilation_context& context,
     const source_information& source_info)
 {

--- a/libelement/src/object_model/call_stack.hpp
+++ b/libelement/src/object_model/call_stack.hpp
@@ -17,12 +17,13 @@ namespace element
             std::vector<object_const_shared_ptr> compiled_arguments;
         };
 
+        call_stack();
         frame& push(std::shared_ptr<const function_instance> function, std::vector<object_const_shared_ptr> compiled_arguments);
         void pop();
 
-        [[nodiscard]] unsigned int recursive_calls(std::shared_ptr<const function_instance> function) const;
+        [[nodiscard]] unsigned int recursive_calls(const function_instance* function) const;
         [[nodiscard]] std::shared_ptr<error> build_recursive_error(
-            std::shared_ptr<const function_instance> function,
+            const function_instance* function,
             const compilation_context& context,
             const source_information& source_info);
 

--- a/libelement/src/object_model/capture_stack.cpp
+++ b/libelement/src/object_model/capture_stack.cpp
@@ -7,6 +7,11 @@
 
 using namespace element;
 
+capture_stack::capture_stack()
+{
+    frames.reserve(100);
+}
+
 void capture_stack::push(const scope* local_scope, const std::vector<port>* parameters, std::vector<object_const_shared_ptr> compiled_arguments)
 {
     frames.emplace_back(frame{ local_scope, parameters, std::move(compiled_arguments) });

--- a/libelement/src/object_model/capture_stack.cpp
+++ b/libelement/src/object_model/capture_stack.cpp
@@ -10,7 +10,8 @@ using namespace element;
 
 capture_stack::capture_stack()
 {
-    frames.reserve(100);
+    // the capture stack can never contain more frames than the callstack
+    frames.reserve(reasonable_function_call_limit);
 }
 
 void capture_stack::push(const scope* local_scope, const std::vector<port>* parameters, std::vector<object_const_shared_ptr> compiled_arguments)

--- a/libelement/src/object_model/capture_stack.cpp
+++ b/libelement/src/object_model/capture_stack.cpp
@@ -4,6 +4,7 @@
 #include "call_stack.hpp"
 #include "scope.hpp"
 #include "declarations/declaration.hpp"
+#include "compilation_context.hpp"
 
 using namespace element;
 
@@ -37,7 +38,7 @@ object_const_shared_ptr capture_stack::find(const scope* local_scope,
     while (current_scope)
     {
         //check the scope and see if it's in there
-        const auto* found = current_scope->find(name, false);
+        const auto* found = current_scope->find(name, context.interpreter->caches, false);
         if (found)
             return found->compile(context, source_info);
 

--- a/libelement/src/object_model/capture_stack.hpp
+++ b/libelement/src/object_model/capture_stack.hpp
@@ -18,7 +18,7 @@ namespace element
             std::vector<object_const_shared_ptr> compiled_arguments;
         };
 
-        capture_stack() = default;
+        capture_stack();
 
         void push(const scope* local_scope, const std::vector<port>* parameters, std::vector<object_const_shared_ptr> compiled_arguments);
         void push(const declaration& declaration, std::vector<object_const_shared_ptr> compiled_arguments);

--- a/libelement/src/object_model/compilation_context.cpp
+++ b/libelement/src/object_model/compilation_context.cpp
@@ -6,6 +6,9 @@
 #include "intrinsics/intrinsic.hpp"
 #include "scope.hpp"
 
+//STD
+#include <exception>
+
 using namespace element;
 
 compilation_context::compilation_context(const scope* const scope, element_interpreter_ctx* interpreter)
@@ -23,7 +26,7 @@ compilation_context::compilation_context(const scope* const scope, element_inter
     if (!body)
         throw; //todo
     list_indexer->set_body(body);
-    success = compiler_scope->add_declaration(std::move(list_indexer));
+    success = compiler_scope->add_declaration(std::move(list_indexer), interpreter->caches);
     if (!success)
         throw; //todo
 

--- a/libelement/src/object_model/compilation_context.cpp
+++ b/libelement/src/object_model/compilation_context.cpp
@@ -22,7 +22,7 @@ compilation_context::compilation_context(const scope* const scope, element_inter
     const auto* body = intrinsic::get_intrinsic(interpreter, *list_indexer);
     if (!body)
         throw; //todo
-    list_indexer->body = body;
+    list_indexer->set_body(body);
     success = compiler_scope->add_declaration(std::move(list_indexer));
     if (!success)
         throw; //todo

--- a/libelement/src/object_model/compilation_context.hpp
+++ b/libelement/src/object_model/compilation_context.hpp
@@ -5,6 +5,7 @@
 #include "capture_stack.hpp"
 #include "interpreter_internal.hpp"
 #include "configuration.hpp"
+#include "scope_caches.hpp"
 
 //todo: move to cpp
 #include "declarations/function_declaration.hpp"
@@ -43,7 +44,6 @@ namespace element
 
     private:
         const scope* global_scope;
-
         //Used to store declarations that aren't in user code, but which we need to store somewhere
         //e.g. a declaration for the compiler-provided list indexer when a user creates a List using the intrinsic function list
         std::unique_ptr<scope> compiler_scope;

--- a/libelement/src/object_model/constraints/bool_type.cpp
+++ b/libelement/src/object_model/constraints/bool_type.cpp
@@ -13,7 +13,7 @@ object_const_shared_ptr bool_type::index(const compilation_context& context, con
     if (!cached)
     {
         cached_declaration = context.get_global_scope()->find(bool_type::name, false);
-        cached = true;
+        //cached = true; //todo: type.hpp defines a static version of this class, unsafe to do caching with multiple interpreters, move ownership to interpreter
     }
 
     if (!cached_declaration)

--- a/libelement/src/object_model/constraints/bool_type.cpp
+++ b/libelement/src/object_model/constraints/bool_type.cpp
@@ -12,7 +12,7 @@ object_const_shared_ptr bool_type::index(const compilation_context& context, con
 {
     if (!cached)
     {
-        cached_declaration = context.get_global_scope()->find(bool_type::name, false);
+        cached_declaration = context.get_global_scope()->find(bool_type::name, context.interpreter->caches, false);
         //cached = true; //todo: type.hpp defines a static version of this class, unsafe to do caching with multiple interpreters, move ownership to interpreter
     }
 

--- a/libelement/src/object_model/constraints/num_type.cpp
+++ b/libelement/src/object_model/constraints/num_type.cpp
@@ -13,7 +13,7 @@ object_const_shared_ptr num_type::index(const compilation_context& context,
 {
     if (!cached)
     {
-        cached_declaration = context.get_global_scope()->find(num_type::name, false);
+        cached_declaration = context.get_global_scope()->find(num_type::name, context.interpreter->caches, false);
         //cached = true; //todo: type.hpp defines a static version of this class, unsafe to do caching with multiple interpreters, move ownership to interpreter
     }
 

--- a/libelement/src/object_model/constraints/num_type.cpp
+++ b/libelement/src/object_model/constraints/num_type.cpp
@@ -14,7 +14,7 @@ object_const_shared_ptr num_type::index(const compilation_context& context,
     if (!cached)
     {
         cached_declaration = context.get_global_scope()->find(num_type::name, false);
-        cached = true;
+        //cached = true; //todo: type.hpp defines a static version of this class, unsafe to do caching with multiple interpreters, move ownership to interpreter
     }
 
     if (!cached_declaration)

--- a/libelement/src/object_model/declarations/declaration.hpp
+++ b/libelement/src/object_model/declarations/declaration.hpp
@@ -35,10 +35,6 @@ namespace element
         [[nodiscard]] virtual object_const_shared_ptr generate_placeholder(const compilation_context& context, int& placeholder_index, unsigned int boundary_scope) const;
 
         [[nodiscard]] virtual std::string location() const;
-        [[nodiscard]] virtual bool recursive_handler(const call_stack& stack, const declaration* other_declaration, std::vector<call_stack::frame>::const_reverse_iterator iterator) const
-        {
-            return !is_intrinsic();
-        }
 
         std::string qualifier;
         identifier name;

--- a/libelement/src/object_model/declarations/function_declaration.hpp
+++ b/libelement/src/object_model/declarations/function_declaration.hpp
@@ -12,6 +12,8 @@ namespace element
     class function_declaration final : public declaration
     {
     public:
+        using body_type = std::variant<std::unique_ptr<object>, const object*>;
+
         enum class kind
         {
             expression_bodied,
@@ -19,7 +21,6 @@ namespace element
             intrinsic
         };
 
-    public:
         function_declaration(identifier name, const scope* parent_scope, kind function_kind);
 
         [[nodiscard]] bool matches_constraint(const compilation_context& context, const constraint* constraint) const override;
@@ -39,11 +40,15 @@ namespace element
         [[nodiscard]] bool valid_at_boundary(const compilation_context& context) const;
         [[nodiscard]] bool is_intrinsic() const override;
 
-        std::variant<std::unique_ptr<object>, const object*> body;
+        [[nodiscard]] const body_type& get_body() const;
+        void set_body(body_type body);
 
     private:
+        body_type body;
         void validate_ports(const compilation_context& context) const;
 
+        mutable bool is_variadic_cached = false;
+        mutable bool cached_variadic = false;
         mutable bool ports_validated = false;
         mutable bool valid_ports = false;
         std::unique_ptr<constraint> constraint_;

--- a/libelement/src/object_model/declarations/namespace_declaration.cpp
+++ b/libelement/src/object_model/declarations/namespace_declaration.cpp
@@ -20,7 +20,7 @@ object_const_shared_ptr namespace_declaration::index(
 {
     if (our_scope)
     {
-        const auto* found = our_scope->find(name, false);
+        const auto* found = our_scope->find(name, context.interpreter->caches, false);
         if (found)
             return found->compile(context, source_info);
 

--- a/libelement/src/object_model/declarations/struct_declaration.cpp
+++ b/libelement/src/object_model/declarations/struct_declaration.cpp
@@ -32,7 +32,7 @@ object_const_shared_ptr struct_declaration::index(
             source_info,
             context.get_logger());
 
-    const auto* found = our_scope->find(name, false);
+    const auto* found = our_scope->find(name, context.interpreter->caches, false);
     if (!found)
         return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, typeof_info());
 
@@ -112,7 +112,7 @@ bool struct_declaration::deserializable(const compilation_context& context) cons
     for (const auto& input : get_inputs())
     {
         //todo: we can cache all of the resolving annotation things everywhere
-        const auto& type = get_scope()->find(input.get_annotation()->to_string(), true);
+        const auto& type = get_scope()->find(input.get_annotation()->to_string(), context.interpreter->caches, true);
         assert(type);
         if (!type->deserializable(context))
             return false;
@@ -136,7 +136,7 @@ object_const_shared_ptr struct_declaration::generate_placeholder(const compilati
     std::vector<object_const_shared_ptr> placeholder_inputs;
     for (const auto& input : get_inputs())
     {
-        const auto& type = get_scope()->find(input.get_annotation()->to_string(), true);
+        const auto& type = get_scope()->find(input.get_annotation()->to_string(), context.interpreter->caches, true);
         auto placeholder = type->generate_placeholder(context, placeholder_index, boundary_scope);
 
         if (!placeholder)

--- a/libelement/src/object_model/expressions/call_expression.cpp
+++ b/libelement/src/object_model/expressions/call_expression.cpp
@@ -22,6 +22,8 @@ call_expression::call_expression(const expression_chain* parent)
 [[nodiscard]] object_const_shared_ptr call_expression::resolve(const compilation_context& context, const object* obj)
 {
     std::vector<object_const_shared_ptr> compiled_arguments;
+    compiled_arguments.reserve(arguments.size());
+
     for (const auto& arg : arguments)
         compiled_arguments.push_back(arg->compile(context, source_info));
 

--- a/libelement/src/object_model/intermediaries/function_instance.cpp
+++ b/libelement/src/object_model/intermediaries/function_instance.cpp
@@ -155,10 +155,11 @@ object_const_shared_ptr function_instance::call(
 
     //todo: we really shouldn't need variant for the body here, there's a better solution
     object_const_shared_ptr element;
-    if (std::holds_alternative<std::unique_ptr<object>>(declarer->body))
-        element = std::get<std::unique_ptr<object>>(declarer->body)->compile(context, source_info);
+    const auto& body = declarer->get_body();
+    if (std::holds_alternative<std::unique_ptr<object>>(body))
+        element = std::get<std::unique_ptr<object>>(body)->compile(context, source_info);
     else
-        element = std::get<const object*>(declarer->body)->compile(context, source_info);
+        element = std::get<const object*>(body)->compile(context, source_info);
 
     std::swap(captures, context.captures);
 

--- a/libelement/src/object_model/intermediaries/function_instance.cpp
+++ b/libelement/src/object_model/intermediaries/function_instance.cpp
@@ -154,7 +154,8 @@ object_const_shared_ptr function_instance::call(
 
     std::swap(captures, context.captures);
 
-    //todo: we really shouldn't need variant for the body here, there's a better solution
+    //todo: the use of std::variant for the body is unecessary, it was just the simplest solution at the time.
+    //std::visit is quite slow, so we're manually doing the branching instead.
     object_const_shared_ptr element;
     const auto& body = declarer->get_body();
     if (std::holds_alternative<std::unique_ptr<object>>(body))

--- a/libelement/src/object_model/intermediaries/function_instance.cpp
+++ b/libelement/src/object_model/intermediaries/function_instance.cpp
@@ -142,7 +142,8 @@ object_const_shared_ptr function_instance::call(
     if (!is_variadic && !valid_call(context, declarer, compiled_args))
         return build_error_for_invalid_call(context, declarer, compiled_args);
 
-    if (context.calls.recursive_calls(this) > 100)
+    //todo: we limit how many recursive calls there can be, as we had issues detecting recursive cases and it was causing errors in reasonable code
+    if (context.calls.recursive_calls(this) > reasonable_function_call_limit)
         return context.calls.build_recursive_error(this, context, source_info);
 
     if constexpr (should_log_compilation_step())

--- a/libelement/src/object_model/intrinsics/intrinsic_binary.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_binary.cpp
@@ -42,8 +42,8 @@ object_const_shared_ptr intrinsic_binary::compile(const compilation_context& con
 
     auto new_expr = std::make_unique<element::instruction_binary>(
         operation,
-        expr1,
-        expr2,
+        std::move(expr1),
+        std::move(expr2),
         return_type);
 
     return evaluate(context, std::move(new_expr));

--- a/libelement/src/object_model/intrinsics/intrinsic_constructor_bool.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_constructor_bool.cpp
@@ -16,8 +16,8 @@ object_const_shared_ptr intrinsic_constructor_bool::call(
     std::vector<object_const_shared_ptr> compiled_args,
     const source_information& source_info) const
 {
-    auto& true_decl = *context.get_global_scope()->find(identifier("True"), false);
-    auto& false_decl = *context.get_global_scope()->find(identifier("False"), false);
+    auto& true_decl = *context.get_global_scope()->find(identifier("True"), context.interpreter->caches, false);
+    auto& false_decl = *context.get_global_scope()->find(identifier("False"), context.interpreter->caches, false);
 
     const auto true_expr = get_intrinsic(context.interpreter, true_decl)->compile(context, source_info);
     const auto false_expr = get_intrinsic(context.interpreter, false_decl)->compile(context, source_info);

--- a/libelement/src/object_model/intrinsics/intrinsic_constructor_list.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_constructor_list.cpp
@@ -17,7 +17,7 @@ object_const_shared_ptr intrinsic_constructor_list::call(
     std::vector<object_const_shared_ptr> compiled_args,
     const source_information& source_info) const
 {
-    const auto* list_decl = context.get_global_scope()->find(identifier{ "List" }, false);
+    const auto* list_decl = context.get_global_scope()->find(identifier{ "List" }, context.interpreter->caches, false);
     assert(list_decl);
     const auto* list_struct = static_cast<const struct_declaration*>(list_decl);
     assert(list_struct);

--- a/libelement/src/object_model/intrinsics/intrinsic_function.hpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_function.hpp
@@ -20,14 +20,16 @@ namespace element
         bool variadic = false;
     };
 
-    static std::shared_ptr<const instruction> evaluate(const compilation_context& context, std::shared_ptr<const instruction> expr)
+    static std::shared_ptr<const instruction> evaluate(const compilation_context& context, instruction_const_shared_ptr expr)
     {
-        std::vector<element_value> outputs = { 0 };
-        const auto result = element_evaluate(*context.interpreter, expr, {}, outputs, {});
+        float output = 0;
+        std::size_t output_count = 1;
+        
+        const auto result = element_evaluate(*context.interpreter, expr, nullptr, 0, &output, output_count, {});
         if (result != ELEMENT_OK)
             return expr;
 
-        auto new_expr = std::make_unique<element::instruction_constant>(outputs[0]);
+        auto new_expr = std::make_shared<const instruction_constant>(output);
         new_expr->actual_type = expr->actual_type;
         return new_expr;
     }

--- a/libelement/src/object_model/intrinsics/intrinsic_list.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_list.cpp
@@ -21,11 +21,11 @@ object_const_shared_ptr intrinsic_list::compile(const compilation_context& conte
 
     assert(count != 0); //todo
 
-    const auto* list_decl = context.get_global_scope()->find(identifier{ "List" }, false);
+    const auto* list_decl = context.get_global_scope()->find(identifier{ "List" }, context.interpreter->caches, false);
     assert(list_decl);
     const auto* list_constructor = intrinsic::get_intrinsic(context.interpreter, *list_decl);
 
-    const auto* list_indexer_decl = context.get_compiler_scope()->find(identifier{ "@list_indexer" }, false);
+    const auto* list_indexer_decl = context.get_compiler_scope()->find(identifier{ "@list_indexer" }, context.interpreter->caches, false);
     assert(list_indexer_decl);
     const auto* list_indexer_func = static_cast<const function_declaration*>(list_indexer_decl);
     assert(list_indexer_func);

--- a/libelement/src/object_model/intrinsics/intrinsic_list_fold.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_list_fold.cpp
@@ -36,15 +36,16 @@ object_const_shared_ptr compile_time_fold(
     indexer_arguments.resize(1);
 
     auto aggregate = initial;
+    const auto list_at = list->index(context, identifier::list_at_identifier, source_info);
     for (int i = 0; i < list_count_constant->value(); ++i)
     {
-        indexer_arguments[0] = std::make_shared<const element::instruction_constant>(static_cast<element_value>(i));
-        auto at_index = list->index(context, identifier::list_at_identifier, source_info)->call(context, indexer_arguments, source_info);
-        if (!at_index->is_constant())
+        indexer_arguments[0] = std::make_shared<const instruction_constant>(static_cast<element_value>(i));
+        auto list_element = list_at->call(context, indexer_arguments, source_info);
+        if (!list_element->is_constant())
             return nullptr;
 
         //note: the order must be maintained across compilers to ensure the same results for non-commutative operations
-        aggregate = accumulator_function->call(context, { std::move(aggregate), std::move(at_index) }, source_info);
+        aggregate = accumulator_function->call(context, { std::move(aggregate), std::move(list_element) }, source_info);
     }
 
     return aggregate;

--- a/libelement/src/object_model/intrinsics/intrinsic_list_fold.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_list_fold.cpp
@@ -81,7 +81,7 @@ object_const_shared_ptr runtime_fold(
             accumulator_function->source_info,
             context.get_logger());
 
-    const auto* listfold = context.get_compiler_scope()->find(identifier{ "@list_fold" }, false);
+    const auto* listfold = context.get_compiler_scope()->find(identifier{ "@list_fold" }, context.interpreter->caches, false);
     if (!listfold)
         return std::make_shared<const error>("failed to find @list_fold", ELEMENT_ERROR_UNKNOWN, source_info, context.get_logger());
 

--- a/libelement/src/object_model/object_internal.cpp
+++ b/libelement/src/object_model/object_internal.cpp
@@ -137,7 +137,7 @@ namespace element
                 source_info,
                 context.get_logger());
 
-        const auto* func = dynamic_cast<const function_declaration*>(type->our_scope->find(name, false));
+        const auto* func = dynamic_cast<const function_declaration*>(type->our_scope->find(name, context.interpreter->caches, false));
 
         //todo: not exactly working type checking, good enough for now though
         const bool has_inputs = func && func->has_inputs();

--- a/libelement/src/object_model/object_internal.hpp
+++ b/libelement/src/object_model/object_internal.hpp
@@ -14,6 +14,12 @@
 
 namespace element
 {
+    /* currently libelement has no way of caching compilation, rewinding the C++ callstack, and then resuming.
+     * this causes the C++ callstack to become prohibitively large, and a stack overflow will occur.
+     * typically this has been seen with element callstacks approaching ~300 function calls.
+     * 100 was chosen as a safe default for how many function calls deep we can be in element, but can be adjusted in the future. */
+    constexpr auto reasonable_function_call_limit = 100;
+
     class object
     {
     public:

--- a/libelement/src/object_model/object_model_builder.cpp
+++ b/libelement/src/object_model/object_model_builder.cpp
@@ -222,7 +222,7 @@ namespace element
         {
             build_scope(context, lambda_body, *lambda_function_decl, output_result);
 
-            const auto* return_func = lambda_function_decl->our_scope->find(identifier::return_identifier, false);
+            const auto* return_func = lambda_function_decl->our_scope->find(identifier::return_identifier, context->caches, false);
             if (!return_func)
             {
                 output_result = log_error(context, context->src_context.get(), expression, log_error_message_code::function_missing_return, lambda_function_decl->name.value);
@@ -265,7 +265,7 @@ namespace element
             assert(!intrinsic);
             build_scope(context, body, *function_decl, output_result);
 
-            const auto* return_func = function_decl->our_scope->find(identifier::return_identifier, false);
+            const auto* return_func = function_decl->our_scope->find(identifier::return_identifier, context->caches, false);
             if (!return_func)
             {
                 output_result = log_error(context, context->src_context.get(), decl, log_error_message_code::function_missing_return, function_decl->name.value);
@@ -312,7 +312,7 @@ namespace element
         bool had_default = false;
         for (const auto& input : function_decl->inputs)
         {
-            if (function_decl->our_scope->find(identifier{ input.get_name() }, false))
+            if (function_decl->our_scope->find(identifier{ input.get_name() }, context->caches, false))
                 output_result = log_error(context, context->src_context.get(), decl, log_error_message_code::multiple_definition_with_parameter, input.get_name(), function_decl->name.value);
 
             if (input.has_default())
@@ -536,7 +536,7 @@ namespace element
             }
 
             assert(decl);
-            const bool success = our_scope->add_declaration(std::move(decl));
+            const bool success = our_scope->add_declaration(std::move(decl), context->caches);
             if (!success)
             {
                 if (output_result == ELEMENT_OK)

--- a/libelement/src/object_model/object_model_builder.cpp
+++ b/libelement/src/object_model/object_model_builder.cpp
@@ -229,14 +229,14 @@ namespace element
                 return nullptr;
             }
 
-            lambda_function_decl->body = return_func;
+            lambda_function_decl->set_body(return_func);
         }
         else
         {
             auto chain = build_expression_chain(context, lambda_body, lambda_function_decl.get(), output_result);
             assert(!chain->expressions.empty());
             assert(chain->expressions[0]);
-            lambda_function_decl->body = std::move(chain);
+            lambda_function_decl->set_body(std::move(chain));
         }
 
         return std::move(lambda_function_decl);
@@ -272,7 +272,7 @@ namespace element
                 return nullptr;
             }
 
-            function_decl->body = return_func;
+            function_decl->set_body(return_func);
         }
         else if (expression_bodied)
         {
@@ -290,7 +290,7 @@ namespace element
                 return nullptr;
             }
 
-            function_decl->body = std::move(chain);
+            function_decl->set_body(std::move(chain));
         }
         else if (intrinsic && body->type == ELEMENT_AST_NODE_NO_BODY)
         {
@@ -301,7 +301,7 @@ namespace element
                 return nullptr;
             }
 
-            function_decl->body = intrinsic::get_intrinsic(context, *function_decl);
+            function_decl->set_body(intrinsic::get_intrinsic(context, *function_decl));
         }
         else
         {

--- a/libelement/src/object_model/port.cpp
+++ b/libelement/src/object_model/port.cpp
@@ -35,7 +35,7 @@ const declaration* port::resolve_annotation(const compilation_context& context) 
     if (!annotation || !declarer)
         return nullptr;
 
-    return declarer->get_scope()->find(annotation->to_string(), true);
+    return declarer->get_scope()->find(annotation->to_string(), context.interpreter->caches, true);
 }
 
 object_const_shared_ptr port::generate_placeholder(const compilation_context& context, int& placeholder_index, unsigned int boundary_scope) const

--- a/libelement/src/object_model/scope.cpp
+++ b/libelement/src/object_model/scope.cpp
@@ -115,7 +115,7 @@ const declaration* scope::find(const identifier& name, const bool recurse = fals
     }
     split_path.push_back(full_path.substr(start, full_path.length() - start));
 
-    static constexpr auto find_identifier = [](const scope& scope, identifier name, bool recurse) -> const declaration* {
+    static constexpr auto find_identifier = [](const scope& scope, const identifier& name, bool recurse) -> const declaration* {
         const auto name_it = scope.declarations.find(name);
 
         if (name_it != scope.declarations.end())

--- a/libelement/src/object_model/scope.cpp
+++ b/libelement/src/object_model/scope.cpp
@@ -3,6 +3,7 @@
 //SELF
 #include "object_model/declarations/declaration.hpp"
 #include "object_model/expressions/expression_chain.hpp"
+#include "object_model/scope_caches.hpp"
 #include "object_model/error.hpp"
 
 using namespace element;
@@ -71,15 +72,25 @@ bool scope::mark_declaration_compiler_generated(const identifier& name)
 //    //return declaration_or_expression ? declaration_or_expression->location() : "Not available";
 //}
 
-bool scope::add_declaration(std::unique_ptr<declaration> declaration)
+bool scope::add_declaration(std::unique_ptr<declaration> declaration, scope_caches& caches)
 {
-    const auto& [it, success] = declarations.try_emplace(declaration->name.value, std::move(declaration));
+    auto name = declaration->name.value;
+    const auto& [it, success] = declarations.try_emplace(std::move(name), std::move(declaration));
+
+    if (success)
+        caches.mark_to_clear();
+
     return success;
 }
 
-bool scope::remove_declaration(const identifier& name)
+bool scope::remove_declaration(const identifier& name, scope_caches& caches)
 {
-    return declarations.erase(name.value) != 0;
+    const bool removed = declarations.erase(name.value) != 0;
+
+    if (removed)
+        caches.mark_to_clear();
+
+    return removed;
 }
 
 const std::map<identifier, std::unique_ptr<declaration>>& scope::get_declarations() const
@@ -93,49 +104,61 @@ std::string scope::get_name() const
     return "";
 }
 
-const declaration* scope::find(const identifier& name, const bool recurse = false) const
+std::vector<std::string> split(const std::string& full_string, char delimiter = '.')
 {
-    const std::string delimiter = ".";
-    const std::string full_path = name.value;
-    std::vector<std::string> split_path;
+    std::vector<std::string> split_strings;
 
     size_t start = 0;
-    auto end = full_path.find(delimiter);
-    if (end != std::string::npos)
+    auto end = full_string.find(delimiter);
+    //find all but last string
+    while (end != std::string::npos)
     {
-        //find all but last string
-        while (end != std::string::npos)
-        {
-            const auto identifier = full_path.substr(start, end - start);
-            split_path.push_back(identifier);
+        const auto identifier = full_string.substr(start, end - start);
+        split_strings.push_back(identifier);
 
-            start = end + delimiter.length();
-            end = full_path.find(delimiter, start);
-        }
+        start = end + 1 /*delimiter legth*/;
+        end = full_string.find(delimiter, start);
     }
-    split_path.push_back(full_path.substr(start, full_path.length() - start));
 
-    static constexpr auto find_identifier = [](const scope& scope, const identifier& name, bool recurse) -> const declaration* {
-        const auto name_it = scope.declarations.find(name);
+    split_strings.push_back(full_string.substr(start, full_string.length() - start));
+    return split_strings;
+}
 
-        if (name_it != scope.declarations.end())
-            return name_it->second.get();
+const declaration* scope::find_identifier(const identifier& name, scope_caches& caches, bool recurse) const
+{
+    const auto name_it = declarations.find(name);
 
-        if (recurse && scope.parent_scope)
-            return scope.parent_scope->find(name, recurse);
+    if (name_it != declarations.end())
+        return name_it->second.get();
 
-        return nullptr;
-    };
+    if (recurse && parent_scope)
+        return parent_scope->find(name, caches, recurse);
 
-    const declaration* decl = find_identifier(*this, identifier{ split_path[0] }, recurse);
-    for (int i = 1; i < split_path.size(); ++i)
+    return nullptr;
+};
+
+const declaration* scope::find(const identifier& name, scope_caches& caches, const bool recurse = false) const
+{
+    auto& cache = caches.get(this);
+    const auto name_it = cache.find(name.value);
+    if (name_it != cache.end())
+        return name_it->second;
+
+    auto split_path = split(name.value);
+
+    const auto* scope = this;
+    const declaration* found_decl = nullptr;
+    for (const auto& ident : split_path)
     {
-        if (!decl)
+        found_decl = scope->find_identifier(ident, caches, recurse);
+        if (!found_decl)
             return nullptr;
-        decl = find_identifier(*decl->our_scope, split_path[i], false);
-    }
 
-    return decl;
+        scope = found_decl->our_scope.get();
+    }
+    
+    cache[name.value] = found_decl;
+    return found_decl;
 }
 
 const scope* scope::get_global() const

--- a/libelement/src/object_model/scope.hpp
+++ b/libelement/src/object_model/scope.hpp
@@ -2,6 +2,7 @@
 
 //STD
 #include <map>
+#include <unordered_map>
 #include <memory>
 
 //SELF
@@ -10,13 +11,15 @@
 
 namespace element
 {
+    class scope_caches;
+
     class scope final : public object, public std::enable_shared_from_this<scope>
     {
     public:
         scope(const scope* parent_scope, const object* declaration_or_expression);
 
         [[nodiscard]] std::string get_name() const override;
-        [[nodiscard]] const declaration* find(const identifier& name, bool recurse) const;
+        [[nodiscard]] const declaration* find(const identifier& name, scope_caches& caches, bool recurse) const;
         [[nodiscard]] bool is_root() const { return parent_scope == nullptr; }
         [[nodiscard]] bool is_empty() const { return declarations.empty(); }
         [[nodiscard]] const scope* get_global() const;
@@ -25,8 +28,8 @@ namespace element
         //[[nodiscard]] std::string location() const;
         [[nodiscard]] std::string to_code(const int depth = -1) const override;
 
-        bool add_declaration(std::unique_ptr<declaration> declaration);
-        bool remove_declaration(const identifier& name);
+        bool add_declaration(std::unique_ptr<declaration> declaration, scope_caches& caches);
+        bool remove_declaration(const identifier& name, scope_caches& caches);
         [[nodiscard]] const std::map<identifier, std::unique_ptr<declaration>>& get_declarations() const;
         element_result merge(std::unique_ptr<scope>&& other);
 
@@ -36,6 +39,8 @@ namespace element
         //const object* declaration_or_expression;
 
     private:
+        const declaration* find_identifier(const identifier& name, scope_caches& caches, bool recurse) const;
+
         const scope* parent_scope = nullptr;
         std::map<identifier, std::unique_ptr<declaration>> declarations;
     };

--- a/libelement/src/object_model/scope_caches.cpp
+++ b/libelement/src/object_model/scope_caches.cpp
@@ -1,0 +1,28 @@
+#include "scope_caches.hpp"
+
+//SELF
+#include "scope.hpp"
+
+//STD
+#include <exception>
+
+using namespace element;
+
+void scope_caches::clear()
+{
+    marked_for_clearing = false;
+    cache.clear();
+}
+
+void scope_caches::mark_to_clear()
+{
+    marked_for_clearing = true;
+}
+
+scope_caches::find_map& scope_caches::get(const scope* scope)
+{
+    if (marked_for_clearing)
+        clear();
+
+    return cache[scope];
+}

--- a/libelement/src/object_model/scope_caches.hpp
+++ b/libelement/src/object_model/scope_caches.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+//STD
+#include <unordered_map>
+#include <string>
+#include <functional>
+
+namespace element
+{
+    class scope;
+    class declaration;
+
+    class scope_caches
+    {
+    public:
+        using find_map = std::unordered_map<std::string, const declaration*>;
+        using scope_map = std::unordered_map<const scope*, find_map>;
+
+        void mark_to_clear();
+        find_map& get(const scope* scope);
+
+    private:
+        void clear();
+
+        bool marked_for_clearing = false;
+        //todo: 3rd party hashmaps like robinhood or absl could be up to twice as fast if this is a big bottleneck
+        scope_map cache;
+    };
+} // namespace element


### PR DESCRIPTION
- Some minor changes here and there to improve compilation performance
- Caching whether a function is variadic, as it uses an expensive std::visit
- Caching lookups in a scope, which has expensive string handling
- Removed an unsafe caching of the static bool/num types, until we move it elsewhere (and scope caching above mostly solves it too). bit of tech debt around this area of code, didn't want to change it too much.

for cache invalidation of lookups in scopes I just simply cleared all of the caches of nested scopes when something is changed. I didn't see any noticeable performance impact, but we can look at using dirty flags and trying to be smarter about it in the future if needed.

I also cleaned up the string splitting happening in the scope lookup while I added caching, makes the commit a little messier due to how github displays diff, so I'd recommend viewing the raw code before/after side by side for that change