### PR TITLE
libelement: slightly improved error messages

### DIFF
--- a/libelement/src/instruction_tree/instructions.hpp
+++ b/libelement/src/instruction_tree/instructions.hpp
@@ -93,9 +93,9 @@ namespace element
         [[nodiscard]] std::string to_string() const override
         {
             if (actual_type == type::boolean.get())
-                return to_bool(m_value) ? "true" : "false";
+                return to_bool(m_value) ? "Bool = true" : "Bool = false";
 
-            return fmt::format("{:g}", m_value);
+            return fmt::format("Num = {:g}", m_value);
         }
 
     private:

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -354,7 +354,7 @@ element_result element_interpreter_evaluate_instruction(
     outputs->count = static_cast<int>(count);
 
     if (result != ELEMENT_OK)
-        interpreter->log(result, fmt::format("Failed to evaluate {}", instruction->instruction->typeof_info()), "<input>");
+        interpreter->log(result, fmt::format("Failed to evaluate {}", instruction->instruction->to_string()), "<input>");
 
     return result;
 }

--- a/libelement/src/object_model/declarations/function_declaration.hpp
+++ b/libelement/src/object_model/declarations/function_declaration.hpp
@@ -28,6 +28,7 @@ namespace element
 
         [[nodiscard]] std::string typeof_info() const override;
         [[nodiscard]] std::string to_code(const int depth) const override;
+        [[nodiscard]] std::string to_string() const override;
         [[nodiscard]] bool is_variadic() const override;
 
         [[nodiscard]] object_const_shared_ptr call(const compilation_context& context,

--- a/libelement/src/object_model/declarations/namespace_declaration.cpp
+++ b/libelement/src/object_model/declarations/namespace_declaration.cpp
@@ -24,7 +24,7 @@ object_const_shared_ptr namespace_declaration::index(
         if (found)
             return found->compile(context, source_info);
 
-        return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, typeof_info());
+        return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, to_string());
     }
 
     throw;

--- a/libelement/src/object_model/declarations/struct_declaration.cpp
+++ b/libelement/src/object_model/declarations/struct_declaration.cpp
@@ -34,7 +34,7 @@ object_const_shared_ptr struct_declaration::index(
 
     const auto* found = our_scope->find(name, context.interpreter->caches, false);
     if (!found)
-        return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, typeof_info());
+        return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, to_string());
 
     return found->compile(context, source_info);
 }

--- a/libelement/src/object_model/error_map.cpp
+++ b/libelement/src/object_model/error_map.cpp
@@ -58,9 +58,12 @@ bool element::detail::register_errors()
         "'{}' was found when indexing '{}' but it is not an instance function.\nnote: the first parameter '{}' is of type '{}'. the first parameter needs to be '{}' for this to be considered an instance function.",
         ELEMENT_ERROR_CANNOT_BE_USED_AS_INSTANCE_FUNCTION);
 
-    element::register_error<std::string, std::string, std::string>(
+    element::register_error<std::string, std::size_t, std::size_t, std::string, std::string>(
         error_message_code::argument_count_mismatch,
-        "attempted to construct an instance of '{}' which requires the parameters '{}', but the parameters of type '{}' were used instead.",
+        "attempted to construct an instance of '{}' with the incorrect number of arguments."
+        "\nnote: {} arguments are required, but {} were passed."
+        "\nThe parameters are '{}'."
+        "\nThe arguments are '{}'.",
         ELEMENT_ERROR_ARGUMENT_COUNT_MISMATCH);
 
     //expand on this

--- a/libelement/src/object_model/expressions/call_expression.cpp
+++ b/libelement/src/object_model/expressions/call_expression.cpp
@@ -37,6 +37,8 @@ call_expression::call_expression(const expression_chain* parent)
     if (element)
         return element;
 
+    //note: we assume that the error will be contained in the returned object, and thus should never be null.
+    //errors should be built where they occur, to make debugging easier and to ensure we have access to all required information
     assert(!"internal compiler error");
     return build_error_and_log(context, source_info, error_message_code::invalid_errorless_call, parent->declarer->name.value);
 }

--- a/libelement/src/object_model/expressions/indexing_expression.cpp
+++ b/libelement/src/object_model/expressions/indexing_expression.cpp
@@ -20,5 +20,5 @@ indexing_expression::indexing_expression(identifier name, const expression_chain
     if (element)
         return element;
 
-    return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, obj->typeof_info());
+    return build_error_and_log(context, source_info, error_message_code::failed_to_find_when_resolving_indexing_expr, name.value, obj->to_string());
 }

--- a/libelement/src/object_model/expressions/lambda_expression.hpp
+++ b/libelement/src/object_model/expressions/lambda_expression.hpp
@@ -15,7 +15,7 @@ namespace element
     public:
         lambda_expression(const expression_chain* parent);
 
-        [[nodiscard]] std::string to_code(const int depth = 0) const override { return function->to_code(depth); };
+        [[nodiscard]] std::string to_code(const int depth = 0) const override { return function->to_code(depth); }
         [[nodiscard]] object_const_shared_ptr resolve(const compilation_context& context, const object* obj) override;
 
         std::unique_ptr<function_declaration> function;

--- a/libelement/src/object_model/intermediaries/function_instance.cpp
+++ b/libelement/src/object_model/intermediaries/function_instance.cpp
@@ -193,7 +193,7 @@ object_const_shared_ptr function_instance::call(
     if (!element->matches_constraint(context, constraint))
         return std::make_shared<error>(
             fmt::format("the return of '{}' was '{}' which doesn't match the constraint '{}'",
-                        declarer->name.value, element->typeof_info(), constraint ? type->name.value : "Any"),
+                        declarer->name.value, element->to_string(), constraint ? type->name.value : "Any"),
             ELEMENT_ERROR_CONSTRAINT_NOT_SATISFIED, source_info);
 
     return element;

--- a/libelement/src/object_model/intermediaries/list_wrapper.cpp
+++ b/libelement/src/object_model/intermediaries/list_wrapper.cpp
@@ -31,7 +31,7 @@ object_const_shared_ptr list_wrapper::create_or_optimise(const object_const_shar
     if (!selector || selector->actual_type != type::num.get())
     {
         return std::make_shared<const error>(
-            "Tried to create a selector but it must be of type 'Num'\nnote: typeof selector is \"" + selector_object->typeof_info() + "\"",
+            "Tried to create a selector but it must be of type 'Num'\nnote: selector is \"" + selector_object->to_string() + "\"",
             ELEMENT_ERROR_UNKNOWN,
             source_info); //todo: pass logger from context
     }

--- a/libelement/src/object_model/object_internal.cpp
+++ b/libelement/src/object_model/object_internal.cpp
@@ -39,19 +39,19 @@ namespace element
     object_const_shared_ptr object::index(const compilation_context& context, const identifier&,
                                           const source_information& source_info) const
     {
-        return build_error_and_log(context, source_info, error_message_code::not_indexable, typeof_info());
+        return build_error_and_log(context, source_info, error_message_code::not_indexable, to_string());
     }
 
     object_const_shared_ptr object::call(const compilation_context& context, std::vector<object_const_shared_ptr>,
                                          const source_information& source_info) const
     {
-        return build_error_and_log(context, source_info, error_message_code::not_callable, typeof_info());
+        return build_error_and_log(context, source_info, error_message_code::not_callable, to_string());
     }
 
     object_const_shared_ptr object::compile(const compilation_context& context,
                                             const source_information& source_info) const
     {
-        return build_error_and_log(context, source_info, error_message_code::not_compilable, typeof_info());
+        return build_error_and_log(context, source_info, error_message_code::not_compilable, to_string());
     }
 
     bool valid_call(
@@ -107,7 +107,7 @@ namespace element
         for (unsigned i = 0; i < compiled_args.size(); ++i)
         {
             const auto& input = compiled_args[i];
-            given_params += fmt::format("({}) _:{}", i, input->typeof_info());
+            given_params += fmt::format("({}) _:{}", i, input->to_string());
             if (i != compiled_args.size() - 1)
                 given_params += ", ";
         }
@@ -115,7 +115,7 @@ namespace element
         if (compiled_args.size() != declarer->inputs.size())
         {
             return build_error(declarer->source_info, error_message_code::argument_count_mismatch,
-                               declarer->location(), input_params, given_params);
+                               declarer->location(), declarer->inputs.size(), compiled_args.size(), input_params, given_params);
         }
 
         auto error_string = fmt::format("constraint not satisfied for function {}\nfunction has {} inputs\nfunction parameters = {}\narguments passed = {}",
@@ -154,15 +154,15 @@ namespace element
 
         if (!has_inputs)
             return build_error_and_log(context, source_info, error_message_code::instance_function_cannot_be_nullary,
-                                       func->typeof_info(), instance->typeof_info());
+                                       func->to_string(), instance->to_string());
 
         if (!has_type)
             return build_error_and_log(context, source_info, error_message_code::is_not_an_instance_function,
-                                       func->typeof_info(), instance->typeof_info(), func->inputs[0].get_name());
+                                       func->to_string(), instance->to_string(), func->inputs[0].get_name());
 
         if (!types_match)
             return build_error_and_log(context, source_info, error_message_code::is_not_an_instance_function,
-                                       func->typeof_info(), instance->typeof_info(),
+                                       func->to_string(), instance->to_string(),
                                        func->inputs[0].get_name(), func->inputs[0].get_annotation()->to_string(), type->name.value);
 
         //did we miss an error that we need to handle?

--- a/libelement/src/object_model/object_model_builder.cpp
+++ b/libelement/src/object_model/object_model_builder.cpp
@@ -363,7 +363,7 @@ namespace element
             result = build_namespace_declaration(context, ast, parent_scope, output_result);
 
         if (flag_set(logging_bitmask, log_flags::debug | log_flags::output_typeof_information))
-            std::cout << result->typeof_info() + "\n";
+            std::cout << result->to_string() + "\n";
 
         return result;
     }

--- a/libelement/src/object_model/type_annotation.hpp
+++ b/libelement/src/object_model/type_annotation.hpp
@@ -20,7 +20,7 @@ namespace element
         }
 
         [[nodiscard]] std::string to_code(const int depth) const;
-        [[nodiscard]] const std::string& to_string() const { return name.value; };
+        [[nodiscard]] const std::string& to_string() const { return name.value; }
 
         source_information source_info;
 


### PR DESCRIPTION
- Replaces typeof_info with to_string, which will contain more useful information in error messages
- Some cleanup in error messages so that information isn't duplicated, and type names exist for literals

This MR does not make error messages better, just slightly more detailed, such that the error message contains relevant names rather than "ExpressionBodied"

A lot more work is needed to make these error messages nice and consistent