### PR TITLE
libelement: expose instruction_to_string & changes

### DIFF
--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -253,6 +253,18 @@ element_result element_instruction_is_constant(
     bool* constant);
 
 /**
+ * @brief converts an instruction in to a human-readable string
+ *
+ * @param[in] instruction       instruction to represent as a string
+ * @param[out] buffer           output buffer
+ * @param[in,out] buffer_size   output buffer size, modified to represent the number of characters written. if buffer is NULL, the required buffer size will be written
+ */
+element_result element_instruction_to_string(
+    element_instruction* instruction,
+    char* buffer,
+    int* buffer_size);
+
+/**
  * @brief finds a declaration from the loaded element code
  *
  * @param[in] interpreter       interpreter context

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -256,13 +256,17 @@ element_result element_instruction_is_constant(
  * @brief converts an instruction in to a human-readable string
  *
  * @param[in] instruction       instruction to represent as a string
- * @param[out] buffer           output buffer
- * @param[in,out] buffer_size   output buffer size, modified to represent the number of characters written. if buffer is NULL, the required buffer size will be written
- */
+ * @param[out] buffer           output buffer. if a non-NULL buffer is passed and ELEMENT_OK is returned, the buffer will be null-terminated.
+ * @param[in,out] buffer_size   output buffer size. this is always modified to be the size required to contain the null-terminated string.
+ * @return ELEMENT_OK either buffer was NULL or buffer was not NULL and buffer_size was sufficiently large
+ * @return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL the instruction is NULL
+ * @return ELEMENT_ERROR_API_INVALID_INPUT the buffer_size is NULL
+ * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER the buffer_size is insufficient and a non-NULL buffer was passed
+*/
 element_result element_instruction_to_string(
     element_instruction* instruction,
     char* buffer,
-    int* buffer_size);
+    size_t* buffer_size);
 
 /**
  * @brief finds a declaration from the loaded element code

--- a/libelement/src/common_internal.hpp
+++ b/libelement/src/common_internal.hpp
@@ -87,7 +87,7 @@ struct element_log_ctx
 
 std::string tokens_to_string(const element_tokeniser_ctx* context, const element_token* nearest_token = nullptr);
 std::string ast_to_string(const element_ast* ast, int depth = 0, const element_ast* ast_to_mark = nullptr);
-std::string instruction_to_string(const element::instruction& expression, std::size_t depth = 0);
+std::string instruction_to_string(const element::instruction& expression, std::size_t depth = 0, std::string prefix = "");
 std::string ast_to_code(const element_ast* node, const element_ast* parent = nullptr);
 
 namespace element

--- a/libelement/src/instruction_tree/instructions.hpp
+++ b/libelement/src/instruction_tree/instructions.hpp
@@ -147,6 +147,16 @@ namespace element
             return std::accumulate(m_dependents.begin(), m_dependents.end(), size_t(0),
                                    [](size_t c, const auto& d) { return c + d->get_size(); });
         }
+        
+        [[nodiscard]] std::string get_type_name() const
+        {
+            return m_debug_type_name;
+        }
+
+        [[nodiscard]] std::vector<std::string> get_field_names() const
+        {
+            return m_debug_dependents_names;
+        }
 
     private:
         std::vector<std::string> m_debug_dependents_names;

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -217,7 +217,7 @@ element_result element_instruction_is_constant(element_instruction* instruction,
 element_result element_instruction_to_string(
     element_instruction* instruction,
     char* buffer,
-    int* buffer_size)
+    size_t* buffer_size)
 {
     if (!instruction || !instruction->instruction)
         return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL;
@@ -225,15 +225,24 @@ element_result element_instruction_to_string(
     if (!buffer_size)
         return ELEMENT_ERROR_API_INVALID_INPUT;
     
-    auto string = instruction_to_string(*instruction->instruction);
+    const auto string = instruction_to_string(*instruction->instruction);
+    const auto required_buffer_size = string.size() + 1;
 
     if (!buffer)
     {
-        *buffer_size = static_cast<int>(string.size());
-        return ELEMENT_ERROR_API_STRING_IS_NULL;
+        *buffer_size = required_buffer_size;
+        return ELEMENT_OK;
     }
 
+    if (*buffer_size < required_buffer_size)
+    {
+        *buffer_size = required_buffer_size;
+        return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
+    }
+    
+    *buffer_size = required_buffer_size;
     strncpy(buffer, string.c_str(), string.size());
+    buffer[string.size()] = '\0';
 
     return ELEMENT_OK;
 }

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -214,6 +214,30 @@ element_result element_instruction_is_constant(element_instruction* instruction,
     return ELEMENT_OK;
 }
 
+element_result element_instruction_to_string(
+    element_instruction* instruction,
+    char* buffer,
+    int* buffer_size)
+{
+    if (!instruction || !instruction->instruction)
+        return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL;
+
+    if (!buffer_size)
+        return ELEMENT_ERROR_API_INVALID_INPUT;
+    
+    auto string = instruction_to_string(*instruction->instruction);
+
+    if (!buffer)
+    {
+        *buffer_size = static_cast<int>(string.size());
+        return ELEMENT_ERROR_API_STRING_IS_NULL;
+    }
+
+    strncpy(buffer, string.c_str(), string.size());
+
+    return ELEMENT_OK;
+}
+
 element_result element_interpreter_find(element_interpreter_ctx* interpreter, const char* path, element_declaration** declaration)
 {
     if (!interpreter)
@@ -468,7 +492,7 @@ element_result element_interpreter_evaluate_expression(
 
     constexpr auto log_expression_tree = flag_set(logging_bitmask, log_flags::debug | log_flags::output_instruction_tree);
     if constexpr (log_expression_tree)
-        interpreter->log("\n------\nEXPRESSION\n------\n" + instruction_to_string(*instruction.instruction));
+        interpreter->log("\n------\nINSTRUCTION TREE\n------\n" + instruction_to_string(*instruction.instruction));
 
     float inputs[] = { 0 };
     element_inputs input;


### PR DESCRIPTION
- Adds index for each option in the instruction tree string
- Adds the pointer of the node, so we can tell which are duplicates
- Exposes the function in the public API, so we can access it elsewhere