### PR TITLE
LMNT: rename API functions to be more user-obvious

### DIFF
--- a/LMNT/README.md
+++ b/LMNT/README.md
@@ -25,7 +25,7 @@ char mem[8192];
 lmnt_result result;
 
 // initialise interpreter context
-result = lmnt_ictx_init(&ctx, mem, sizeof(mem));
+result = lmnt_init(&ctx, mem, sizeof(mem));
 assert(result == LMNT_OK);
 
 // acquire the archive from the user
@@ -33,11 +33,11 @@ const char* archive = get_archive_from_user();
 size_t archive_size = get_archive_size_from_user();
 
 // load the archive (this can also be loaded in stages)
-result = lmnt_ictx_load_archive(&ctx, archive, archive_size);
+result = lmnt_load_archive(&ctx, archive, archive_size);
 assert(result == LMNT_OK);
 
 // prepare and validate the archive to ensure it's valid
-result = lmnt_ictx_prepare_archive(&ctx, NULL);
+result = lmnt_prepare_archive(&ctx, NULL);
 assert(result == LMNT_OK);
 
 // find the function we want to execute

--- a/LMNT/doc/ExecutionModel.md
+++ b/LMNT/doc/ExecutionModel.md
@@ -6,10 +6,10 @@ The LMNT runtime can best be described as a variable-count register machine: eac
 
 These are the steps that take an LMNT runtime from having an archive sat in external memory to being ready to execute:
 
-1. Interpreter is initialised using `lmnt_ictx_init`
+1. Interpreter is initialised using `lmnt_init`
    * This involves handing the interpreter a static block of memory to work with
-1. Archive is loaded into the interpreter using `lmnt_ictx_load_archive`
-1. Archive is "prepared"/validated using `lmnt_ictx_prepare_archive`
+2. Archive is loaded into the interpreter using `lmnt_load_archive`
+3. Archive is "prepared"/validated using `lmnt_prepare_archive`
    * This performs extensive validation on the archive's contents
      * The archive header describes the size of the archive's tables
      * Each string in the strings table is checked to ensure that its length matches and that it ends with a null terminator
@@ -17,9 +17,9 @@ These are the steps that take an LMNT runtime from having an archive sat in exte
      * Code for every def is checked to ensure it does not attempt to run any illegal instructions or perform any out-of-bounds access
      * The data table is checked for consistency
      * The alignment of the data table and constants table is verified
-1. A def is located via `lmnt_ictx_find_def`
-1. The def's inputs are set via `lmnt_update_args`
-1. Either:
+4. A def is located via `lmnt_find_def`
+5. The def's inputs are set via `lmnt_update_args`
+6. Either:
    * The def can be executed in the interpreter using `lmnt_execute`
    * The def can be JIT-compiled using `lmnt_jit_compile` and then executed with `lmnt_jit_execute`
 

--- a/LMNT/doc/JIT.md
+++ b/LMNT/doc/JIT.md
@@ -7,8 +7,8 @@ The JIT makes use of [a fork of the DynASM library](https://github.com/Esvandiar
 
 ## Workflow
 
-1. The archive is loaded and validated as normal (`lmnt_ictx_load_archive`, `lmnt_ictx_prepare_archive`)
-2. The user selects an LMNT function (`lmnt_ictx_find_def`)
+1. The archive is loaded and validated as normal (`lmnt_load_archive`, `lmnt_prepare_archive`)
+2. The user selects an LMNT function (`lmnt_find_def`)
 3. This function is compiled to native code (`lmnt_jit_compile`)
 4. The user chooses the inputs to use (`lmnt_update_args`)
 5. The native function is executed instead of using the interpreter (`lmnt_jit_execute`)

--- a/LMNT/include/lmnt/archive.h
+++ b/LMNT/include/lmnt/archive.h
@@ -87,24 +87,24 @@ typedef struct lmnt_data_section
 lmnt_result lmnt_archive_init(lmnt_archive* archive, const char* data, size_t size);
 lmnt_result lmnt_archive_print(const lmnt_archive* archive);
 
-lmnt_result lmnt_get_constant(const lmnt_archive* archive, uint32_t offset, lmnt_value* value);
-lmnt_result lmnt_get_constants(const lmnt_archive* archive, uint32_t offset, const lmnt_value** value);
-lmnt_result lmnt_get_constants_count(const lmnt_archive* archive, lmnt_offset* value);
+lmnt_result lmnt_archive_get_constant(const lmnt_archive* archive, uint32_t offset, lmnt_value* value);
+lmnt_result lmnt_archive_get_constants(const lmnt_archive* archive, uint32_t offset, const lmnt_value** value);
+lmnt_result lmnt_archive_get_constants_count(const lmnt_archive* archive, lmnt_offset* value);
 
-int32_t lmnt_get_string(const lmnt_archive* archive, uint32_t offset, const char** ptr);
+int32_t lmnt_archive_get_string(const lmnt_archive* archive, uint32_t offset, const char** ptr);
 
-lmnt_result lmnt_get_def(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_def** def);
-lmnt_result lmnt_get_def_code(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_code** code, const lmnt_instruction** instructions);
-lmnt_result lmnt_find_def(const lmnt_archive* archive, const char* name, const lmnt_def** def);
-lmnt_result lmnt_get_def_bases(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_loffset** bases);
+lmnt_result lmnt_archive_get_def(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_def** def);
+lmnt_result lmnt_archive_get_def_code(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_code** code, const lmnt_instruction** instructions);
+lmnt_result lmnt_archive_find_def(const lmnt_archive* archive, const char* name, const lmnt_def** def);
+lmnt_result lmnt_archive_get_def_bases(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_loffset** bases);
 
-lmnt_result lmnt_get_code(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_code** code);
-lmnt_result lmnt_get_code_instructions(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_instruction** instrs);
+lmnt_result lmnt_archive_get_code(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_code** code);
+lmnt_result lmnt_archive_get_code_instructions(const lmnt_archive* archive, lmnt_loffset offset, const lmnt_instruction** instrs);
 
-lmnt_result lmnt_get_data_sections_count(const lmnt_archive* archive, lmnt_offset* count);
-lmnt_result lmnt_get_data_section(const lmnt_archive* archive, lmnt_offset index, const lmnt_data_section** section);
-lmnt_result lmnt_get_data_block(const lmnt_archive* archive, const lmnt_data_section* section, const lmnt_value** block);
+lmnt_result lmnt_archive_get_data_sections_count(const lmnt_archive* archive, lmnt_offset* count);
+lmnt_result lmnt_archive_get_data_section(const lmnt_archive* archive, lmnt_offset index, const lmnt_data_section** section);
+lmnt_result lmnt_archive_get_data_block(const lmnt_archive* archive, const lmnt_data_section* section, const lmnt_value** block);
 
-lmnt_result lmnt_update_def_extcalls(lmnt_archive* archive, const lmnt_extcall_info* table, size_t table_count);
+lmnt_result lmnt_archive_update_def_extcalls(lmnt_archive* archive, const lmnt_extcall_info* table, size_t table_count);
 
 #endif

--- a/LMNT/include/lmnt/extcalls.h
+++ b/LMNT/include/lmnt/extcalls.h
@@ -17,11 +17,11 @@ struct lmnt_extcall_info
     lmnt_extcall_fn function;
 };
 
-lmnt_result lmnt_ictx_extcalls_get(const lmnt_ictx* ctx, const lmnt_extcall_info** table, size_t* table_count);
-lmnt_result lmnt_ictx_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* table, size_t table_count);
+lmnt_result lmnt_extcalls_get(const lmnt_ictx* ctx, const lmnt_extcall_info** table, size_t* table_count);
+lmnt_result lmnt_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* table, size_t table_count);
 
-lmnt_result lmnt_ictx_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt_extcall_info** result);
-lmnt_result lmnt_ictx_extcall_find(const lmnt_ictx* ctx, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, const lmnt_extcall_info** result);
+lmnt_result lmnt_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt_extcall_info** result);
+lmnt_result lmnt_extcall_find(const lmnt_ictx* ctx, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, const lmnt_extcall_info** result);
 lmnt_result lmnt_extcall_find_index(const lmnt_extcall_info* table, size_t table_size, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, size_t* index);
 
 #endif

--- a/LMNT/include/lmnt/interpreter.h
+++ b/LMNT/include/lmnt/interpreter.h
@@ -44,41 +44,41 @@ struct lmnt_ictx
 // Initialise an interpreter context with the specified memory area and size in bytes
 // The memory space passed in must remain allocated for the lifetime of the context
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_init(lmnt_ictx* ctx, char* mem, size_t mem_size);
+lmnt_result lmnt_init(lmnt_ictx* ctx, char* mem, size_t mem_size);
 
 // Load an archive into the specified interpreter context
 // This copies the contents of data into the context's memory space
 // As a result, the memory pointed to by data does not need to remain alive beyond returning from this function
 // Note that essentially no validation is performed on the archive by loading it
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_load_archive(lmnt_ictx* ctx, const char* data, size_t data_size);
+lmnt_result lmnt_load_archive(lmnt_ictx* ctx, const char* data, size_t data_size);
 
 // Begin loading an archive into the specified interpreter context
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_load_archive_begin(lmnt_ictx* ctx);
+lmnt_result lmnt_load_archive_begin(lmnt_ictx* ctx);
 // Appends data to the specified interpreter context's current archive
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_load_archive_append(lmnt_ictx* ctx, const char* data, size_t data_size);
+lmnt_result lmnt_load_archive_append(lmnt_ictx* ctx, const char* data, size_t data_size);
 // Finishes loading the current archive into the specified interpreter context
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_load_archive_end(lmnt_ictx* ctx);
+lmnt_result lmnt_load_archive_end(lmnt_ictx* ctx);
 
 // Load an archive into the specified intepreter context, using the archive data in place
 // This copies the archive's constants table into the context's memory space
 // The archive data passed in must remain alive for the duration this archive is loaded
 // Note that essentially no validation is performed on the archive by loading it
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_load_inplace_archive(lmnt_ictx* ctx, const char* data, size_t data_size);
+lmnt_result lmnt_load_inplace_archive(lmnt_ictx* ctx, const char* data, size_t data_size);
 
 // Validates the archive's contents and fills in some information only available at runtime
 // The validation_result argument is optional and can be NULL
 // If a validation error occurs, this function will return LMNT_ERROR_INVALID_ARCHIVE
 // In this case, if a valid pointer has been passed in as validation_result, it will write a more detailed error
 // Returns: LMNT_OK or an error
-lmnt_result lmnt_ictx_prepare_archive(lmnt_ictx* ctx, lmnt_validation_result* validation_result);
+lmnt_result lmnt_prepare_archive(lmnt_ictx* ctx, lmnt_validation_result* validation_result);
 
-// Convenience function for lmnt_find_def
-lmnt_result lmnt_ictx_find_def(const lmnt_ictx* ctx, const char* name, const lmnt_def** def);
+// Convenience function for lmnt_archive_find_def
+lmnt_result lmnt_find_def(const lmnt_ictx* ctx, const char* name, const lmnt_def** def);
 
 LMNT_ATTR_FAST lmnt_result lmnt_update_args(
     lmnt_ictx* ctx, const lmnt_def* def,

--- a/LMNT/src/extcalls.c
+++ b/LMNT/src/extcalls.c
@@ -2,14 +2,14 @@
 #include "lmnt/interpreter.h"
 #include <string.h>
 
-lmnt_result lmnt_ictx_extcalls_get(const lmnt_ictx* ctx, const lmnt_extcall_info** table, size_t* table_count)
+lmnt_result lmnt_extcalls_get(const lmnt_ictx* ctx, const lmnt_extcall_info** table, size_t* table_count)
 {
     *table = ctx->extcalls;
     *table_count = ctx->extcalls_count;
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* table, size_t table_count)
+lmnt_result lmnt_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* table, size_t table_count)
 {
     ctx->extcalls = table;
     ctx->extcalls_count = table_count;
@@ -17,7 +17,7 @@ lmnt_result lmnt_ictx_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* tabl
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt_extcall_info** result)
+lmnt_result lmnt_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt_extcall_info** result)
 {
     if (index >= ctx->extcalls_count)
         return LMNT_ERROR_NOT_FOUND;
@@ -25,7 +25,7 @@ lmnt_result lmnt_ictx_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_extcall_find(const lmnt_ictx* ctx, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, const lmnt_extcall_info** result)
+lmnt_result lmnt_extcall_find(const lmnt_ictx* ctx, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, const lmnt_extcall_info** result)
 {
     size_t index;
     LMNT_OK_OR_RETURN(lmnt_extcall_find_index(ctx->extcalls, ctx->extcalls_count, name, args_count, rvals_count, &index));

--- a/LMNT/src/interpreter.c
+++ b/LMNT/src/interpreter.c
@@ -10,7 +10,7 @@
 extern lmnt_op_fn lmnt_op_functions[LMNT_OP_END];
 extern lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END];
 
-lmnt_result lmnt_ictx_init(lmnt_ictx* ctx, char* mem, size_t mem_size)
+lmnt_result lmnt_init(lmnt_ictx* ctx, char* mem, size_t mem_size)
 {
     memset(ctx, 0, sizeof(lmnt_ictx));
 
@@ -25,20 +25,20 @@ lmnt_result lmnt_ictx_init(lmnt_ictx* ctx, char* mem, size_t mem_size)
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_load_archive(lmnt_ictx* ctx, const char* data, size_t data_size)
+lmnt_result lmnt_load_archive(lmnt_ictx* ctx, const char* data, size_t data_size)
 {
-    LMNT_OK_OR_RETURN(lmnt_ictx_load_archive_begin(ctx));
-    LMNT_OK_OR_RETURN(lmnt_ictx_load_archive_append(ctx, data, data_size));
-    LMNT_OK_OR_RETURN(lmnt_ictx_load_archive_end(ctx));
+    LMNT_OK_OR_RETURN(lmnt_load_archive_begin(ctx));
+    LMNT_OK_OR_RETURN(lmnt_load_archive_append(ctx, data, data_size));
+    LMNT_OK_OR_RETURN(lmnt_load_archive_end(ctx));
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_load_archive_begin(lmnt_ictx* ctx)
+lmnt_result lmnt_load_archive_begin(lmnt_ictx* ctx)
 {
     return lmnt_archive_init(&ctx->archive, ctx->memory_area, 0);
 }
 
-lmnt_result lmnt_ictx_load_archive_append(lmnt_ictx* ctx, const char* data, size_t data_size)
+lmnt_result lmnt_load_archive_append(lmnt_ictx* ctx, const char* data, size_t data_size)
 {
     if (data_size >= ctx->memory_area_size - ctx->archive.size)
         return LMNT_ERROR_MEMORY_SIZE;
@@ -47,18 +47,18 @@ lmnt_result lmnt_ictx_load_archive_append(lmnt_ictx* ctx, const char* data, size
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_load_archive_end(lmnt_ictx* ctx)
+lmnt_result lmnt_load_archive_end(lmnt_ictx* ctx)
 {
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_load_inplace_archive(lmnt_ictx* ctx, const char* data, size_t data_size)
+lmnt_result lmnt_load_inplace_archive(lmnt_ictx* ctx, const char* data, size_t data_size)
 {
     // Don't copy the archive in, just use it where it is
     return lmnt_archive_init(&ctx->archive, data, data_size);
 }
 
-lmnt_result lmnt_ictx_prepare_archive(lmnt_ictx* ctx, lmnt_validation_result* vresult)
+lmnt_result lmnt_prepare_archive(lmnt_ictx* ctx, lmnt_validation_result* vresult)
 {
     lmnt_validation_result vr = lmnt_archive_validate(&ctx->archive, ctx->memory_area_size, &ctx->stack_count);
     if (vresult)
@@ -83,7 +83,7 @@ lmnt_result lmnt_ictx_prepare_archive(lmnt_ictx* ctx, lmnt_validation_result* vr
     ctx->writable_stack = ctx->stack + constants_count;
 
     // fill in extern defs' code value to point to the right extcall
-    lmnt_result er = lmnt_update_def_extcalls(&ctx->archive, ctx->extcalls, ctx->extcalls_count);
+    lmnt_result er = lmnt_archive_update_def_extcalls(&ctx->archive, ctx->extcalls, ctx->extcalls_count);
     if (er != LMNT_OK)
         return LMNT_ERROR_MISSING_EXTCALL;
 
@@ -143,7 +143,7 @@ LMNT_ATTR_FAST static lmnt_result execute(lmnt_ictx* ctx, lmnt_value* rvals, con
     else
     {
         const lmnt_extcall_info* extcall;
-        LMNT_OK_OR_RETURN(lmnt_ictx_extcall_get(ctx, def->code, &extcall));
+        LMNT_OK_OR_RETURN(lmnt_extcall_get(ctx, def->code, &extcall));
 
         lmnt_value* const eargs = &ctx->writable_stack[0];
         lmnt_value* const ervals = &ctx->writable_stack[extcall->args_count];
@@ -221,7 +221,7 @@ lmnt_result lmnt_update_args(
     return LMNT_OK;
 }
 
-lmnt_result lmnt_ictx_find_def(const lmnt_ictx* ctx, const char* name, const lmnt_def** def)
+lmnt_result lmnt_find_def(const lmnt_ictx* ctx, const char* name, const lmnt_def** def)
 {
-    return lmnt_find_def(&ctx->archive, name, def);
+    return lmnt_archive_find_def(&ctx->archive, name, def);
 }

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -335,8 +335,8 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
 
     // Work out if we're executing a locally-defined block or an extern one
     const lmnt_code* defcode;
-    LMNT_OK_OR_RETURN(lmnt_get_code(&ctx->archive, def->code, &defcode));
-    LMNT_OK_OR_RETURN(lmnt_get_code_instructions(&ctx->archive, def->code, &state->instructions));
+    LMNT_OK_OR_RETURN(lmnt_archive_get_code(&ctx->archive, def->code, &defcode));
+    LMNT_OK_OR_RETURN(lmnt_archive_get_code_instructions(&ctx->archive, def->code, &state->instructions));
     state->in_count = defcode->instructions_count;
 
     // Nothing fancy on ARMv7-M :(
@@ -1152,7 +1152,7 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             lmnt_loffset def_offset = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
             const lmnt_def* def = validated_get_def(&ctx->archive, def_offset);
             const lmnt_extcall_info* extcall;
-            result = lmnt_ictx_extcall_get(ctx, def->code, &extcall);
+            result = lmnt_extcall_get(ctx, def->code, &extcall);
             if (result != LMNT_OK) break;
             // Make sure that anything the extcall has access to isn't cached
             platformWriteAndEvictByStack(state, in.arg3, in.arg3 + extcall->args_count + extcall->rvals_count);

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -277,8 +277,8 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
 
     // Work out if we're executing a locally-defined block or an extern one
     const lmnt_code* defcode;
-    LMNT_OK_OR_RETURN(lmnt_get_code(&ctx->archive, def->code, &defcode));
-    LMNT_OK_OR_RETURN(lmnt_get_code_instructions(&ctx->archive, def->code, &state->instructions));
+    LMNT_OK_OR_RETURN(lmnt_archive_get_code(&ctx->archive, def->code, &defcode));
+    LMNT_OK_OR_RETURN(lmnt_archive_get_code_instructions(&ctx->archive, def->code, &state->instructions));
     state->in_count = defcode->instructions_count;
 
     state->cpuflags = get_x86_cpu_flags();
@@ -1144,7 +1144,7 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             lmnt_loffset def_offset = LMNT_COMBINE_OFFSET(in.arg1, in.arg2);
             const lmnt_def* def = validated_get_def(&ctx->archive, def_offset);
             const lmnt_extcall_info* extcall;
-            result = lmnt_ictx_extcall_get(ctx, def->code, &extcall);
+            result = lmnt_extcall_get(ctx, def->code, &extcall);
             if (result != LMNT_OK) break;
             // Make sure that anything the extcall has access to isn't cached
             platformWriteAndEvictByStack(state, in.arg3, in.arg3 + extcall->args_count + extcall->rvals_count);

--- a/LMNT/src/jit/jit.c
+++ b/LMNT/src/jit/jit.c
@@ -42,7 +42,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
     else
     {
         const lmnt_extcall_info* extcall;
-        LMNT_OK_OR_RETURN(lmnt_ictx_extcall_get(ctx, def->code, &extcall));
+        LMNT_OK_OR_RETURN(lmnt_extcall_get(ctx, def->code, &extcall));
 
         lmnt_value* const eargs = &ctx->writable_stack[0];
         lmnt_value* const ervals = &ctx->writable_stack[extcall->args_count];

--- a/LMNT/src/ops_fncall.c
+++ b/LMNT/src/ops_fncall.c
@@ -14,7 +14,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_extcall(lmnt_ictx* ctx, lmnt_offset deflo, lm
 
     // During the archive prep stage, the extcall index is put into the def's code member
     const lmnt_extcall_info* extcall;
-    LMNT_OK_OR_RETURN(lmnt_ictx_extcall_get(ctx, def->code, &extcall));
+    LMNT_OK_OR_RETURN(lmnt_extcall_get(ctx, def->code, &extcall));
 
     lmnt_value* const eargs = &ctx->stack[stack_pos];
     lmnt_value* const ervals = &ctx->stack[stack_pos + extcall->args_count];

--- a/LMNT/test/test_fncall.h
+++ b/LMNT/test/test_fncall.h
@@ -143,7 +143,7 @@ static void test_extcall_direct(void)
     lmnt_extcall_info extcalls[] = {
         { "extcall", 1, 1, (lmnt_extcall_fn)(&test_extcall_good) }
     };
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_extcalls_set(ctx, extcalls, 1), LMNT_OK);
+    CU_ASSERT_EQUAL_FATAL(lmnt_extcalls_set(ctx, extcalls, 1), LMNT_OK);
 
     archive a = create_archive_array_with_extcall("test", 3, 1, 4, 1, 0, 0,
         LMNT_OP_BYTES(LMNT_OP_EXTCALL, 0x15, 0x00, 0x02)
@@ -197,7 +197,7 @@ static void test_extcall_indirect(void)
     lmnt_extcall_info extcalls[] = {
         { "extcall", 1, 1, (lmnt_extcall_fn)(&test_extcall_good) }
     };
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_extcalls_set(ctx, extcalls, 1), LMNT_OK);
+    CU_ASSERT_EQUAL_FATAL(lmnt_extcalls_set(ctx, extcalls, 1), LMNT_OK);
 
     archive a = create_archive_array_with_extcall("test", 3, 1, 4, 1, 0, 0,
         LMNT_OP_BYTES(LMNT_OP_EXTCALL, 0x15, 0x00, 0x02)
@@ -251,7 +251,7 @@ static void test_extcall_recursion(void)
     lmnt_extcall_info extcalls[] = {
         { "extcall", 1, 1, (lmnt_extcall_fn)(&test_extcall_good) }
     };
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_extcalls_set(ctx, extcalls, 1), LMNT_OK);
+    CU_ASSERT_EQUAL_FATAL(lmnt_extcalls_set(ctx, extcalls, 1), LMNT_OK);
 
     archive a = create_archive_array_with_extcall("test", 3, 1, 4, 1, 0, 0,
         LMNT_OP_BYTES(LMNT_OP_EXTCALL, 0x00, 0x00, 0x02)

--- a/LMNT/test/testhelpers.h
+++ b/LMNT/test/testhelpers.h
@@ -55,7 +55,7 @@ static lmnt_ictx* create_interpreter_with_size(size_t bufsize)
 {
     lmnt_ictx* ictx = (lmnt_ictx*)malloc(sizeof(lmnt_ictx));
     char* mem = (char*)calloc(bufsize, sizeof(char));
-    if (lmnt_ictx_init(ictx, mem, bufsize) == LMNT_OK) {
+    if (lmnt_init(ictx, mem, bufsize) == LMNT_OK) {
         return ictx;
     } else {
         free(mem);

--- a/LMNT/test/testsetup_interpreter.h
+++ b/LMNT/test/testsetup_interpreter.h
@@ -14,20 +14,20 @@
 
 #undef  TEST_LOAD_ARCHIVE
 #define TEST_LOAD_ARCHIVE(ctx, name, a, fndata) \
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
+    CU_ASSERT_EQUAL_FATAL(lmnt_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
     {\
         lmnt_validation_result vr;\
-        CU_ASSERT_EQUAL_FATAL(lmnt_ictx_prepare_archive((ctx), &vr), LMNT_OK);\
+        CU_ASSERT_EQUAL_FATAL(lmnt_prepare_archive((ctx), &vr), LMNT_OK);\
         CU_ASSERT_EQUAL_FATAL(vr, LMNT_VALIDATION_OK);\
     }\
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_find_def((ctx), (name), &((fndata).def)), LMNT_OK);
+    CU_ASSERT_EQUAL_FATAL(lmnt_find_def((ctx), (name), &((fndata).def)), LMNT_OK);
 
 #undef  TEST_LOAD_ARCHIVE_FAILS_VALIDATION
 #define TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, name, a, fndata, code, vcode) \
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
+    CU_ASSERT_EQUAL_FATAL(lmnt_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
     {\
         lmnt_validation_result vr;\
-        CU_ASSERT_EQUAL_FATAL(lmnt_ictx_prepare_archive((ctx), &vr), (code));\
+        CU_ASSERT_EQUAL_FATAL(lmnt_prepare_archive((ctx), &vr), (code));\
         CU_ASSERT_EQUAL_FATAL(vr, (vcode));\
     }
 

--- a/LMNT/test/testsetup_jit_native.h
+++ b/LMNT/test/testsetup_jit_native.h
@@ -15,12 +15,12 @@
 
 #undef  TEST_LOAD_ARCHIVE
 #define TEST_LOAD_ARCHIVE(ctx, name, a, fndata) \
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
+    CU_ASSERT_EQUAL_FATAL(lmnt_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
     {\
         lmnt_validation_result vr;\
-        CU_ASSERT_EQUAL_FATAL(lmnt_ictx_prepare_archive((ctx), &vr), LMNT_OK);\
+        CU_ASSERT_EQUAL_FATAL(lmnt_prepare_archive((ctx), &vr), LMNT_OK);\
         CU_ASSERT_EQUAL_FATAL(vr, LMNT_VALIDATION_OK);\
-        CU_ASSERT_EQUAL_FATAL(lmnt_ictx_find_def((ctx), (name), &((fndata).def)), LMNT_OK);\
+        CU_ASSERT_EQUAL_FATAL(lmnt_find_def((ctx), (name), &((fndata).def)), LMNT_OK);\
         lmnt_jit_fn_data* jitfn = (lmnt_jit_fn_data*)calloc(1, sizeof(lmnt_jit_fn_data));\
         CU_ASSERT_EQUAL_FATAL(lmnt_jit_compile((ctx), (fndata).def, LMNT_JIT_TARGET_NATIVE, jitfn), LMNT_OK);\
         (fndata).data = jitfn;\
@@ -28,10 +28,10 @@
 
 #undef  TEST_LOAD_ARCHIVE_FAILS_VALIDATION
 #define TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, name, a, fndata, code, vcode) \
-    CU_ASSERT_EQUAL_FATAL(lmnt_ictx_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
+    CU_ASSERT_EQUAL_FATAL(lmnt_load_archive((ctx), (a).buf, (a).size), LMNT_OK);\
     {\
         lmnt_validation_result vr;\
-        CU_ASSERT_EQUAL_FATAL(lmnt_ictx_prepare_archive((ctx), &vr), (code));\
+        CU_ASSERT_EQUAL_FATAL(lmnt_prepare_archive((ctx), &vr), (code));\
         CU_ASSERT_EQUAL_FATAL(vr, (vcode));\
     }
 

--- a/LMNT/testapp/main.c
+++ b/LMNT/testapp/main.c
@@ -152,20 +152,20 @@ int main(int argc, char** argv)
 
     lmnt_ictx ctx;
     char mem[8192];
-    lmnt_result ir = lmnt_ictx_init(&ctx, mem, sizeof(mem));
+    lmnt_result ir = lmnt_init(&ctx, mem, sizeof(mem));
     assert(ir == LMNT_OK);
 
     lmnt_extcall_info extcalls[] = {
         { "double", 1, 1, double_a_thing },
     };
-    lmnt_result xr = lmnt_ictx_extcalls_set(&ctx, extcalls, 1);
+    lmnt_result xr = lmnt_extcalls_set(&ctx, extcalls, 1);
     assert(xr == LMNT_OK);
 
-    lmnt_result lr = lmnt_ictx_load_archive(&ctx, THE_TEST, sizeof(THE_TEST));
+    lmnt_result lr = lmnt_load_archive(&ctx, THE_TEST, sizeof(THE_TEST));
     assert(lr == LMNT_OK);
 
     lmnt_validation_result lvr;
-    lmnt_result vr = lmnt_ictx_prepare_archive(&ctx, &lvr);
+    lmnt_result vr = lmnt_prepare_archive(&ctx, &lvr);
     assert(vr == LMNT_OK);
     if (vr != LMNT_OK) {
         printf("VALIDATION FAILED: %u\n", lvr);
@@ -173,7 +173,7 @@ int main(int argc, char** argv)
     }
     
     const lmnt_def* def;
-    lmnt_result dr = lmnt_find_def(&ctx.archive, THE_TEST_DEF, &def);
+    lmnt_result dr = lmnt_find_def(&ctx, THE_TEST_DEF, &def);
     assert(dr == LMNT_OK);
     if (dr != LMNT_OK) {
         printf("FAILED TO FIND DEF: %s\n", THE_TEST_DEF);
@@ -182,8 +182,8 @@ int main(int argc, char** argv)
 
     const lmnt_code* defcode;
     const lmnt_instruction* instructions;
-    lmnt_get_code(&ctx.archive, def->code, &defcode);
-    lmnt_get_code_instructions(&ctx.archive, def->code, &instructions);
+    lmnt_archive_get_code(&ctx.archive, def->code, &defcode);
+    lmnt_archive_get_code_instructions(&ctx.archive, def->code, &instructions);
 
     lmnt_value c_args[] = THE_TEST_ARGS;
     lmnt_value c_rvals[THE_TEST_RVALS_SIZE];


### PR DESCRIPTION
- Renamed lmnt_ictx_* to be lmnt_* since they're the primary API
- Renamed archive-related functions to be lmnt_archive_*
- Changed a few calls to use validated functions since we've already checked it's validated