### PR TITLE
libelement: LMNT compiler

### DIFF
--- a/Element.NET.TestHelpers/HostArguments.cs
+++ b/Element.NET.TestHelpers/HostArguments.cs
@@ -31,7 +31,8 @@ namespace Element.NET.TestHelpers
                                    : new ProcessHostInfo(name, 
                                        new []{Get<string>("build-command") ,Get<string>("additional-build-command")},
                                        Path.Combine(_elementRootDirectory.Value, Get<string>("executable-path")), 
-                                       Get<string>("working-directory"));
+                                       Get<string>("working-directory"),
+                                       Get<string>("executable-extra-args"));
         }
 
         private static readonly Lazy<string> _elementRootDirectory = new Lazy<string>(() =>
@@ -59,18 +60,20 @@ namespace Element.NET.TestHelpers
 
         private class ProcessHostInfo
         {
-            public ProcessHostInfo(string name, string[] buildCommands, string executablePath, string workingDirectory)
+            public ProcessHostInfo(string name, string[] buildCommands, string executablePath, string workingDirectory, string executableExtraArgs)
             {
                 Name = name;
                 BuildCommands = buildCommands;
                 ExecutablePath = executablePath;
                 WorkingDirectory = workingDirectory;
+                ExecutableExtraArgs = executableExtraArgs;
             }
 
             public string Name { get; }
             public string[] BuildCommands { get; }
             public string ExecutablePath { get; }
             public string WorkingDirectory { get; }
+            public string ExecutableExtraArgs { get; }
         }
 
         private static readonly ProcessHostInfo? _processHostInfo;
@@ -190,7 +193,7 @@ namespace Element.NET.TestHelpers
                     StartInfo = new ProcessStartInfo
                     {
                         FileName = _info.ExecutablePath,
-                        Arguments = arguments,
+                        Arguments = $"{arguments} {_processHostInfo?.ExecutableExtraArgs}",
                         WorkingDirectory = Path.Combine(_elementRootDirectory.Value, _info.WorkingDirectory)
                     }
                 };

--- a/LMNT/include/lmnt/archive.h
+++ b/LMNT/include/lmnt/archive.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_ARCHIVE_H
 #define LMNT_ARCHIVE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
@@ -103,5 +107,10 @@ lmnt_result lmnt_archive_get_data_section(const lmnt_archive* archive, lmnt_offs
 lmnt_result lmnt_archive_get_data_block(const lmnt_archive* archive, const lmnt_data_section* section, const lmnt_value** block);
 
 lmnt_result lmnt_archive_update_def_extcalls(lmnt_archive* archive, const lmnt_extcall_info* table, size_t table_count);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/arm/platform.h
+++ b/LMNT/include/lmnt/arm/platform.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_ARM_PLATFORM_H
 #define LMNT_ARM_PLATFORM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // #if !defined(LMNT_MEMCPY)
 // #define LMNT_MEMORY_HEADER "some_arm_fast_memcpy.h"
 // #define LMNT_MEMCPY lmnt_memcpy_fast
@@ -19,5 +23,10 @@
 
 // Allow use of non-volatile registers?
 #define LMNT_JIT_ARM_ALLOW_NV_REGISTERS
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/common.h
+++ b/LMNT/include/lmnt/common.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_COMMON_H
 #define LMNT_COMMON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -112,6 +116,11 @@ typedef struct lmnt_ictx lmnt_ictx;
 #else
 #define LMNT_LIKELY(expr) (expr)
 #define LMNT_UNLIKELY(expr) (expr)
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/LMNT/include/lmnt/common.h
+++ b/LMNT/include/lmnt/common.h
@@ -87,17 +87,27 @@ typedef LMNT_VALUE_TYPE lmnt_value;
 struct lmnt_ictx;
 typedef struct lmnt_ictx lmnt_ictx;
 
+// Add compiler hints to help out branch prediction
+#if defined(LMNT_COMPILER_GCC) || defined(LMNT_COMPILER_CLANG)
+#define LMNT_LIKELY(expr)    (__builtin_expect(!!(expr), 1))
+#define LMNT_UNLIKELY(expr)  (__builtin_expect(!!(expr), 0))
+#else
+#define LMNT_LIKELY(expr) (expr)
+#define LMNT_UNLIKELY(expr) (expr)
+#endif
+
+// Convenience macros for checking an operation succeeded
 #define LMNT_OK_OR_RETURN(t) \
 { \
     const lmnt_result ok_or_return_result = (t); \
-    if (ok_or_return_result != LMNT_OK) \
+    if (LMNT_UNLIKELY(ok_or_return_result != LMNT_OK)) \
         return ok_or_return_result; \
 }
 
 #define LMNT_V_OK_OR_RETURN(t) \
 { \
     const lmnt_validation_result ok_or_return_result = (t); \
-    if (ok_or_return_result != LMNT_VALIDATION_OK) \
+    if (LMNT_UNLIKELY(ok_or_return_result != LMNT_VALIDATION_OK)) \
         return ok_or_return_result; \
 }
 
@@ -108,14 +118,6 @@ typedef struct lmnt_ictx lmnt_ictx;
 // MSVC does not currently include the C11-standard _Static_assert, only the C++-style variant
 #if defined(_MSC_VER)
 #define _Static_assert static_assert
-#endif
-
-#if defined(LMNT_COMPILER_GCC) || defined(LMNT_COMPILER_CLANG)
-#define LMNT_LIKELY(expr)    (__builtin_expect(!!(expr), 1))
-#define LMNT_UNLIKELY(expr)  (__builtin_expect(!!(expr), 0))
-#else
-#define LMNT_LIKELY(expr) (expr)
-#define LMNT_UNLIKELY(expr) (expr)
 #endif
 
 

--- a/LMNT/include/lmnt/config.h
+++ b/LMNT/include/lmnt/config.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_CONFIG_H
 #define LMNT_CONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/platform.h"
 
 // Header which will be included when requiring memory-related functions
@@ -33,6 +37,11 @@
 // Never called unless requested by the user (e.g. lmnt_archive_print) or debug flags are enabled
 #if !defined(LMNT_PRINTF)
 #define LMNT_PRINTF printf
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/LMNT/include/lmnt/config.h
+++ b/LMNT/include/lmnt/config.h
@@ -12,8 +12,6 @@ extern "C" {
 #define LMNT_MEMORY_HEADER <string.h>
 #endif
 
-#include LMNT_MEMORY_HEADER
-
 // Memory copy/move function
 #if !defined(LMNT_MEMCPY)
 #define LMNT_MEMCPY memcpy
@@ -35,9 +33,17 @@ extern "C" {
 
 // printf function to use for debugging output
 // Never called unless requested by the user (e.g. lmnt_archive_print) or debug flags are enabled
+#if !defined(LMNT_PRINTF_HEADER)
+#define LMNT_PRINTF_HEADER <stdio.h>
+#endif
+
 #if !defined(LMNT_PRINTF)
 #define LMNT_PRINTF printf
 #endif
+
+// Prints every instruction evaluated
+// This is, unsurprisingly, VERY spammy
+// #define LMNT_DEBUG_PRINT_EVALUATED_INSTRUCTIONS
 
 
 #ifdef __cplusplus

--- a/LMNT/include/lmnt/extcalls.h
+++ b/LMNT/include/lmnt/extcalls.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_EXTCALLS_H
 #define LMNT_EXTCALLS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include "lmnt/common.h"
 
@@ -23,5 +27,10 @@ lmnt_result lmnt_extcalls_set(lmnt_ictx* ctx, const lmnt_extcall_info* table, si
 lmnt_result lmnt_extcall_get(const lmnt_ictx* ctx, size_t index, const lmnt_extcall_info** result);
 lmnt_result lmnt_extcall_find(const lmnt_ictx* ctx, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, const lmnt_extcall_info** result);
 lmnt_result lmnt_extcall_find_index(const lmnt_extcall_info* table, size_t table_size, const char* name, lmnt_offset args_count, lmnt_offset rvals_count, size_t* index);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/interpreter.h
+++ b/LMNT/include/lmnt/interpreter.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_INTERPRETER_H
 #define LMNT_INTERPRETER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <assert.h>
 #include <stdlib.h>
 #include "lmnt/common.h"
@@ -113,5 +117,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_resume(
 // Note that there is currently no thread-safety mechanism in the library
 // This is implemented as a single pointer write, which may be atomic on the target architecture
 lmnt_result lmnt_interrupt(lmnt_ictx* ctx);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/jit.h
+++ b/LMNT/include/lmnt/jit.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_JIT_H
 #define LMNT_JIT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -44,5 +48,10 @@ lmnt_result lmnt_jit_delete_function(lmnt_jit_fn_data* fndata);
 LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
     lmnt_ictx* ctx, const lmnt_def* def, const lmnt_jit_fn_data* fndata,
     lmnt_value* rvals, const lmnt_offset rvals_count);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/jitconfig.h
+++ b/LMNT/include/lmnt/jitconfig.h
@@ -1,6 +1,10 @@
 #if !defined(LMNT_JITCONFIG_H)
 #define LMNT_JITCONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/platform.h"
 
 //
@@ -29,6 +33,11 @@
 // Signature: void fn(void*, size_t)
 #if !defined(LMNT_JIT_FREE_CFN_MEMORY)
 #define LMNT_JIT_FREE_CFN_MEMORY(buf, sz) hostFreeCompiledBuffer((buf), (sz))
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/LMNT/include/lmnt/opcodes.h
+++ b/LMNT/include/lmnt/opcodes.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPCODES_H
 #define LMNT_OPCODES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 typedef uint16_t lmnt_opcode;
@@ -139,9 +143,14 @@ typedef struct
     lmnt_operand_type operand3;
 } lmnt_op_info;
 
-extern const lmnt_op_info lmnt_opcode_info[LMNT_OP_END];
+const lmnt_op_info* lmnt_get_opcode_info(lmnt_opcode op);
 
 #define LMNT_OP16(a) (char)(a & 0xFF), (char)((a >> 8) & 0xFF)
 #define LMNT_OP_BYTES(op, arg1, arg2, arg3) LMNT_OP16(op), LMNT_OP16(arg1), LMNT_OP16(arg2), LMNT_OP16(arg3)
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/opcodes.h
+++ b/LMNT/include/lmnt/opcodes.h
@@ -93,6 +93,8 @@ enum
     LMNT_OP_INDEXRIR,
     // compare: stack, stack, null
     LMNT_OP_CMP,
+    // compare: stack, null, null
+    LMNT_OP_CMPZ,
     // branch: null, codelo, codehi
     LMNT_OP_BRANCH,
     LMNT_OP_BRANCHCEQ,

--- a/LMNT/include/lmnt/ops_bounds.h
+++ b/LMNT/include/lmnt/ops_bounds.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPS_BOUNDS_H
 #define LMNT_OPS_BOUNDS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
@@ -23,5 +27,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_maxss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 LMNT_ATTR_FAST lmnt_result lmnt_op_maxvv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 LMNT_ATTR_FAST lmnt_result lmnt_op_minvs(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 LMNT_ATTR_FAST lmnt_result lmnt_op_maxvs(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/ops_branch.h
+++ b/LMNT/include/lmnt/ops_branch.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPS_BRANCH_H
 #define LMNT_OPS_BRANCH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
@@ -25,5 +29,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_branchnz(lmnt_ictx* ctx, lmnt_offset arg1, lm
 LMNT_ATTR_FAST lmnt_result lmnt_op_branchpos(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 LMNT_ATTR_FAST lmnt_result lmnt_op_branchneg(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 LMNT_ATTR_FAST lmnt_result lmnt_op_branchun(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/ops_branch.h
+++ b/LMNT/include/lmnt/ops_branch.h
@@ -8,6 +8,7 @@
 LMNT_ATTR_FAST lmnt_result lmnt_op_return(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_cmp(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+LMNT_ATTR_FAST lmnt_result lmnt_op_cmpz(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_branch(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 

--- a/LMNT/include/lmnt/ops_fncall.h
+++ b/LMNT/include/lmnt/ops_fncall.h
@@ -1,10 +1,19 @@
 #ifndef LMNT_OPS_FNCALL_H
 #define LMNT_OPS_FNCALL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_extcall(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/ops_math.h
+++ b/LMNT/include/lmnt/ops_math.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPS_MATH_H
 #define LMNT_OPS_MATH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
@@ -33,5 +37,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_log2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_o
 LMNT_ATTR_FAST lmnt_result lmnt_op_log10(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_sumv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/ops_misc.h
+++ b/LMNT/include/lmnt/ops_misc.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPS_MISC_H
 #define LMNT_OPS_MISC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
@@ -25,5 +29,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_indexris(lmnt_ictx* ctx, lmnt_offset arg1, lm
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexrir(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_interrupt(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/ops_trig.h
+++ b/LMNT/include/lmnt/ops_trig.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_OPS_TRIG_H
 #define LMNT_OPS_TRIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lmnt/common.h"
 #include "lmnt/opcodes.h"
 #include "lmnt/interpreter.h"
@@ -16,5 +20,10 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_atan(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_o
 LMNT_ATTR_FAST lmnt_result lmnt_op_atan2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_sincos(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/platform.h
+++ b/LMNT/include/lmnt/platform.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_PLATFORM_H
 #define LMNT_PLATFORM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_M_X64) || defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__amd64)
 #define LMNT_ARCH_X86
 #define LMNT_ARCH_X86_64
@@ -45,6 +49,11 @@
 #endif
 #if defined(LMNT_ARCH_ARM)
 #include "lmnt/arm/platform.h"
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/LMNT/include/lmnt/validation.h
+++ b/LMNT/include/lmnt/validation.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_VALIDATION_H
 #define LMNT_VALIDATION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include "lmnt/common.h"
 #include "lmnt/archive.h"
@@ -11,5 +15,10 @@ lmnt_validation_result lmnt_archive_validate(lmnt_archive* archive, size_t memor
     if (!((a)->flags & LMNT_ARCHIVE_VALIDATED)) \
         return LMNT_ERROR_UNPREPARED_ARCHIVE; \
 }
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/x86_64/memcpy_fast.h
+++ b/LMNT/include/lmnt/x86_64/memcpy_fast.h
@@ -29,6 +29,10 @@
 #ifndef LMNT_FAST_MEMCPY_H
 #define LMNT_FAST_MEMCPY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 #include <emmintrin.h>
@@ -705,5 +709,9 @@ static void* lmnt_memcpy_fast(void *destination, const void *source, size_t size
 	return destination;
 }
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/include/lmnt/x86_64/platform.h
+++ b/LMNT/include/lmnt/x86_64/platform.h
@@ -1,6 +1,10 @@
 #ifndef LMNT_X86_64_PLATFORM_H
 #define LMNT_X86_64_PLATFORM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if !defined(LMNT_MEMCPY)
     #define LMNT_MEMORY_HEADER "lmnt/x86_64/memcpy_fast.h"
     #define LMNT_MEMCPY lmnt_memcpy_fast
@@ -13,5 +17,10 @@
 
 // Allow use of non-volatile registers?
 #define LMNT_JIT_X86_64_ALLOW_NV_REGISTERS
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/LMNT/src/archive.c
+++ b/LMNT/src/archive.c
@@ -209,7 +209,7 @@ lmnt_result lmnt_archive_print(const lmnt_archive* archive)
 
         const lmnt_instruction* insts = (const lmnt_instruction*)(get_code_segment(archive) + offset);
         for (size_t i = 0; i < chdr->instructions_count; ++i)
-            LMNT_PRINTF("                 Instructions[%3zu]: %10s %04X %04X %04X\n", i, lmnt_opcode_info[insts[i].opcode].name, insts[i].arg1, insts[i].arg2, insts[i].arg3);
+            LMNT_PRINTF("                 Instructions[%3zu]: %10s %04X %04X %04X\n", i, lmnt_get_opcode_info(insts[i].opcode)->name, insts[i].arg1, insts[i].arg2, insts[i].arg3);
 
         offset += chdr->instructions_count * sizeof(lmnt_instruction);
     }

--- a/LMNT/src/interpreter.c
+++ b/LMNT/src/interpreter.c
@@ -155,8 +155,8 @@ LMNT_ATTR_FAST static lmnt_result execute(lmnt_ictx* ctx, lmnt_value* rvals, con
         ctx->cur_def = NULL;
         ctx->cur_stack_count = 0;
     }
-    // If we hit a return instruction, that's an OK return
-    if (opresult == LMNT_RETURNING) {
+    // If we hit a return instruction or a branch past the function end, that's an OK return
+    if (opresult == LMNT_RETURNING || opresult == LMNT_BRANCHING) {
         opresult = LMNT_OK;
     }
 

--- a/LMNT/src/interpreter.c
+++ b/LMNT/src/interpreter.c
@@ -102,21 +102,23 @@ LMNT_ATTR_FAST static inline lmnt_result execute_instruction(lmnt_ictx* ctx, con
     return ctx->op_functions[op.opcode](ctx, op.arg1, op.arg2, op.arg3);
 }
 
+#if defined(LMNT_DEBUG_PRINT_EVALUATED_INSTRUCTIONS)
 static inline void print_execution_context(lmnt_ictx* ctx, lmnt_loffset inst_idx, const lmnt_instruction op)
 {
-    printf("Eval[%02X]: % 12s %04X %04X %04X [", inst_idx, lmnt_get_opcode_info(op.opcode)->name, op.arg1, op.arg2, op.arg3);
+    LMNT_PRINTF("Eval[%02X]: % 12s %04X %04X %04X [", inst_idx, lmnt_get_opcode_info(op.opcode)->name, op.arg1, op.arg2, op.arg3);
     const size_t count = validated_get_constants_count(&ctx->archive) + ctx->cur_def->stack_count_unaligned;
     for (size_t i = 0; i < count; ++i)
     {
         if (i) printf(", ");
-        printf("%8.3f", ctx->stack[i]);
+        LMNT_PRINTF("%8.3f", ctx->stack[i]);
     }
-    printf("] [%s %s %s %s]\n",
+    LMNT_PRINTF("] [%s %s %s %s]\n",
         (ctx->status_flags & LMNT_ISTATUS_CMP_EQ) ? "EQ" : "  ",
         (ctx->status_flags & LMNT_ISTATUS_CMP_LT) ? "LT" : "  ",
         (ctx->status_flags & LMNT_ISTATUS_CMP_GT) ? "GT" : "  ",
         (ctx->status_flags & LMNT_ISTATUS_CMP_UN) ? "UN" : "  ");
 }
+#endif
 
 // This function assumes:
 // - ctx->cur_def has been set to the def to be executed

--- a/LMNT/src/interpreter.c
+++ b/LMNT/src/interpreter.c
@@ -7,6 +7,11 @@
 #include <math.h>
 #include <string.h>
 
+#include LMNT_MEMORY_HEADER
+#if defined(LMNT_DEBUG_PRINT_EVALUATED_INSTRUCTIONS)
+    #include LMNT_PRINTF_HEADER
+#endif
+
 extern lmnt_op_fn lmnt_op_functions[LMNT_OP_END];
 extern lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END];
 
@@ -97,6 +102,22 @@ LMNT_ATTR_FAST static inline lmnt_result execute_instruction(lmnt_ictx* ctx, con
     return ctx->op_functions[op.opcode](ctx, op.arg1, op.arg2, op.arg3);
 }
 
+static inline void print_execution_context(lmnt_ictx* ctx, lmnt_loffset inst_idx, const lmnt_instruction op)
+{
+    printf("Eval[%02X]: % 12s %04X %04X %04X [", inst_idx, lmnt_get_opcode_info(op.opcode)->name, op.arg1, op.arg2, op.arg3);
+    const size_t count = validated_get_constants_count(&ctx->archive) + ctx->cur_def->stack_count_unaligned;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (i) printf(", ");
+        printf("%8.3f", ctx->stack[i]);
+    }
+    printf("] [%s %s %s %s]\n",
+        (ctx->status_flags & LMNT_ISTATUS_CMP_EQ) ? "EQ" : "  ",
+        (ctx->status_flags & LMNT_ISTATUS_CMP_LT) ? "LT" : "  ",
+        (ctx->status_flags & LMNT_ISTATUS_CMP_GT) ? "GT" : "  ",
+        (ctx->status_flags & LMNT_ISTATUS_CMP_UN) ? "UN" : "  ");
+}
+
 // This function assumes:
 // - ctx->cur_def has been set to the def to be executed
 // - ctx->cur_instr is set to 0 for new execution or its previous value for resume
@@ -128,6 +149,9 @@ LMNT_ATTR_FAST static lmnt_result execute(lmnt_ictx* ctx, lmnt_value* rvals, con
         for (instr = ctx->cur_instr; instr < icount; ++instr)
         {
             opresult = execute_instruction(ctx, instructions[instr]);
+#if defined(LMNT_DEBUG_PRINT_EVALUATED_INSTRUCTIONS)
+            print_execution_context(ctx, instr, instructions[instr]);
+#endif
             if (LMNT_UNLIKELY(opresult != LMNT_OK)) {
                 if (opresult == LMNT_BRANCHING) {
                     // the context's instruction pointer has been updated, refresh

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -1063,6 +1063,12 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | vmrs
             break;
 
+        case LMNT_OP_CMPZ:
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, vtmps1);
+            | vcmpz.f32 s(reg1)
+            | vmrs
+            break;
+
         case LMNT_OP_BRANCHCEQ:
             platformWriteAndEvictAll(state);
             | beq =>cur_branch
@@ -1189,6 +1195,18 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         if (result != LMNT_OK)
             break;
 #endif
+    }
+
+    // has someone made a branch target to the end of the function?
+    if (state->cur_in == next_target) {
+        // if we may have just jumped here, our cache status is unknown, so nuke everything
+        platformWriteAndEvictAll(state);
+        // find which label(s) we're meant to be
+        for (size_t t = 0; t < num_pc_labels; ++t) {
+            if (state->cur_in == branch_targets[t]) {
+                | =>t:
+            }
+        }
     }
 
     | ->ok_return:

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -13,6 +13,7 @@
 #include "jit/hosthelpers.h"
 #include "jit/targethelpers-arm.h" // includes dasm_proto
 #include "jit/reghelpers-arm-vfp.h"
+#include LMNT_MEMORY_HEADER
 
 | .arch armv7m
 | .section rodata, code

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -744,6 +744,11 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | blx r1
             | vpush {s0-s0}
             | reads 0, in.arg2
+            // check for arg2 == 0
+            | vcmpz.f32 s0
+            | vmrs
+            | beq >2
+            // otherwise run logf
             | ldr r1, <1
             | blx r1
             | vpop {s1-s1}
@@ -754,6 +759,18 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
                 | vdiv.f32 s1, s1, s0
                 | writes in.arg3, 1
             }
+            | b >3
+            // if arg2 == 0, write a NaN
+            |2:
+            | vpop {s1-s1}
+            if (acquireScalarRegister(state, in.arg3, &reg3, ACCESSTYPE_WRITE)) {
+                | vldr s(reg3), ->nanbits
+                notifyRegisterWritten(state, reg3, 1);
+            } else {
+                | vldr s1, ->nanbits
+                | writes in.arg3, 1
+            }
+            |3:
             ||rmode = RMODE_UNKNOWN;
             break;
         case LMNT_OP_LN:

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -16,6 +16,7 @@
 #include "jit/hosthelpers.h"
 #include "jit/targethelpers-x86.h" // includes dasm_proto
 #include "jit/reghelpers-x86.h"
+#include LMNT_MEMORY_HEADER
 
 
 | .arch x64

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -1043,6 +1043,12 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | ucomiss xmm(reg1), xmm(reg2)
             break;
 
+        case LMNT_OP_CMPZ:
+            ||acquireScalarRegisterOrLoad(state, in.arg1, &reg1, ACCESSTYPE_READ, xmmtmp1);
+            | xorps xmm(xmmtmp2), xmm(xmmtmp2)
+            | ucomiss xmm(reg1), xmm(xmmtmp2)
+            break;
+
         case LMNT_OP_BRANCHCEQ:
             platformWriteAndEvictAll(state);
             | jp >1
@@ -1176,6 +1182,18 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         if (result != LMNT_OK)
             break;
 #endif
+    }
+
+    // has someone made a branch target to the end of the function?
+    if (state->cur_in == next_target) {
+        // if we may have just jumped here, our cache status is unknown, so nuke everything
+        platformWriteAndEvictAll(state);
+        // find which label(s) we're meant to be
+        for (size_t t = 0; t < num_pc_labels; ++t) {
+            if (state->cur_in == branch_targets[t]) {
+                | =>t:
+            }
+        }
     }
 
     | ->ok_return:

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -743,11 +743,19 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
             | sub rsp, 16  // remain 16-byte aligned for call to logf
             | movss dword [rsp], xmm0
             | reads xmm0, in.arg2
+            // check for arg2 == 0
+            | xorps xmm1, xmm1
+            | ucomiss xmm1, xmm0
+            | je >1
             | mov64 rax, (const intptr_t)(&logf)
             | call rax
             | movss xmm1, dword [rsp]
-            | add rsp, 16
             | divss xmm1, xmm0
+            | jmp >2
+            |1:
+            | movss xmm1, dword [->nanbits]
+            |2:
+            | add rsp, 16
             if (acquireScalarRegister(state, in.arg3, &reg3, ACCESSTYPE_WRITE)) {
                 | movss xmm(reg3), xmm1
                 notifyRegisterWritten(state, reg3, 1);

--- a/LMNT/src/jit/jit.c
+++ b/LMNT/src/jit/jit.c
@@ -5,6 +5,8 @@
 #include "jit/hosthelpers.h"
 #include "helpers.h"
 
+#include LMNT_MEMORY_HEADER
+
 #if defined(LMNT_JIT_HAS_X86_64)
 lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_jit_fn_data* fndata, lmnt_jit_compile_stats* stats);
 #endif

--- a/LMNT/src/jit/jithelpers.h
+++ b/LMNT/src/jit/jithelpers.h
@@ -90,9 +90,9 @@ static inline size_t getAccessSize(lmnt_offset inst, int arg)
     lmnt_operand_type optype;
     switch (arg)
     {
-    case 1: optype = lmnt_opcode_info[inst].operand1; break;
-    case 2: optype = lmnt_opcode_info[inst].operand2; break;
-    case 3: optype = lmnt_opcode_info[inst].operand3; break;
+    case 1: optype = lmnt_get_opcode_info(inst)->operand1; break;
+    case 2: optype = lmnt_get_opcode_info(inst)->operand2; break;
+    case 3: optype = lmnt_get_opcode_info(inst)->operand3; break;
     default: return 0;
     }
     switch (optype)

--- a/LMNT/src/opcodes.c
+++ b/LMNT/src/opcodes.c
@@ -166,6 +166,11 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
     { "EXTCALL",   LMNT_OPERAND_DEFPTR,   LMNT_OPERAND_DEFPTR,   LMNT_OPERAND_STACKN   },
 };
 
+const lmnt_op_info* lmnt_get_opcode_info(lmnt_opcode op)
+{
+    return (op < LMNT_OP_END) ? &(lmnt_opcode_info[op]) : NULL;
+}
+
 lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END] = {
     lmnt_op_interrupt,
     lmnt_op_interrupt,

--- a/LMNT/src/opcodes.c
+++ b/LMNT/src/opcodes.c
@@ -168,7 +168,7 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
 
 const lmnt_op_info* lmnt_get_opcode_info(lmnt_opcode op)
 {
-    return (op < LMNT_OP_END) ? &(lmnt_opcode_info[op]) : NULL;
+    return LMNT_LIKELY(op < LMNT_OP_END) ? &(lmnt_opcode_info[op]) : NULL;
 }
 
 lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END] = {

--- a/LMNT/src/opcodes.c
+++ b/LMNT/src/opcodes.c
@@ -70,6 +70,7 @@ LMNT_ATTR_FAST lmnt_op_fn lmnt_op_functions[LMNT_OP_END] = {
     lmnt_op_indexris,
     lmnt_op_indexrir,
     lmnt_op_cmp,
+    lmnt_op_cmpz,
     lmnt_op_branch,
     lmnt_op_branchceq,
     lmnt_op_branchcne,
@@ -148,6 +149,7 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
     { "INDEXRIS",  LMNT_OPERAND_STACKREF, LMNT_OPERAND_IMM,      LMNT_OPERAND_STACK1   },
     { "INDEXRIR",  LMNT_OPERAND_STACKREF, LMNT_OPERAND_IMM,      LMNT_OPERAND_STACKREF },
     { "CMP",       LMNT_OPERAND_STACK1,   LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED   },
+    { "CMPZ",      LMNT_OPERAND_STACK1,   LMNT_OPERAND_UNUSED,   LMNT_OPERAND_UNUSED   },
     { "BRANCH",    LMNT_OPERAND_UNUSED,   LMNT_OPERAND_CODEPTR,  LMNT_OPERAND_CODEPTR  },
     { "BRANCHCEQ", LMNT_OPERAND_UNUSED,   LMNT_OPERAND_CODEPTR,  LMNT_OPERAND_CODEPTR  },
     { "BRANCHCNE", LMNT_OPERAND_UNUSED,   LMNT_OPERAND_CODEPTR,  LMNT_OPERAND_CODEPTR  },
@@ -165,6 +167,7 @@ const lmnt_op_info lmnt_opcode_info[LMNT_OP_END] = {
 };
 
 lmnt_op_fn lmnt_interrupt_functions[LMNT_OP_END] = {
+    lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,
     lmnt_op_interrupt,

--- a/LMNT/src/ops_bounds.c
+++ b/LMNT/src/ops_bounds.c
@@ -2,6 +2,10 @@
 #include <math.h>
 
 
+#define MIN(a, b) ((b) < (a) ? (b) : (a))
+#define MAX(a, b) ((a) < (b) ? (b) : (a))
+
+
 LMNT_ATTR_FAST lmnt_result lmnt_op_abss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
     ctx->stack[arg3] = fabsf(ctx->stack[arg1]);
@@ -83,48 +87,48 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_truncv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_minss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3] = fminf(ctx->stack[arg1], ctx->stack[arg2]);
+    ctx->stack[arg3] = MIN(ctx->stack[arg1], ctx->stack[arg2]);
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_minvv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3 + 0] = fminf(ctx->stack[arg1 + 0], ctx->stack[arg2 + 0]);
-    ctx->stack[arg3 + 1] = fminf(ctx->stack[arg1 + 1], ctx->stack[arg2 + 1]);
-    ctx->stack[arg3 + 2] = fminf(ctx->stack[arg1 + 2], ctx->stack[arg2 + 2]);
-    ctx->stack[arg3 + 3] = fminf(ctx->stack[arg1 + 3], ctx->stack[arg2 + 3]);
+    ctx->stack[arg3 + 0] = MIN(ctx->stack[arg1 + 0], ctx->stack[arg2 + 0]);
+    ctx->stack[arg3 + 1] = MIN(ctx->stack[arg1 + 1], ctx->stack[arg2 + 1]);
+    ctx->stack[arg3 + 2] = MIN(ctx->stack[arg1 + 2], ctx->stack[arg2 + 2]);
+    ctx->stack[arg3 + 3] = MIN(ctx->stack[arg1 + 3], ctx->stack[arg2 + 3]);
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_maxss(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3] = fmaxf(ctx->stack[arg1], ctx->stack[arg2]);
+    ctx->stack[arg3] = MAX(ctx->stack[arg1], ctx->stack[arg2]);
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_maxvv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3 + 0] = fmaxf(ctx->stack[arg1 + 0], ctx->stack[arg2 + 0]);
-    ctx->stack[arg3 + 1] = fmaxf(ctx->stack[arg1 + 1], ctx->stack[arg2 + 1]);
-    ctx->stack[arg3 + 2] = fmaxf(ctx->stack[arg1 + 2], ctx->stack[arg2 + 2]);
-    ctx->stack[arg3 + 3] = fmaxf(ctx->stack[arg1 + 3], ctx->stack[arg2 + 3]);
+    ctx->stack[arg3 + 0] = MAX(ctx->stack[arg1 + 0], ctx->stack[arg2 + 0]);
+    ctx->stack[arg3 + 1] = MAX(ctx->stack[arg1 + 1], ctx->stack[arg2 + 1]);
+    ctx->stack[arg3 + 2] = MAX(ctx->stack[arg1 + 2], ctx->stack[arg2 + 2]);
+    ctx->stack[arg3 + 3] = MAX(ctx->stack[arg1 + 3], ctx->stack[arg2 + 3]);
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_minvs(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3 + 0] = fminf(ctx->stack[arg1 + 0], ctx->stack[arg2]);
-    ctx->stack[arg3 + 1] = fminf(ctx->stack[arg1 + 1], ctx->stack[arg2]);
-    ctx->stack[arg3 + 2] = fminf(ctx->stack[arg1 + 2], ctx->stack[arg2]);
-    ctx->stack[arg3 + 3] = fminf(ctx->stack[arg1 + 3], ctx->stack[arg2]);
+    ctx->stack[arg3 + 0] = MIN(ctx->stack[arg1 + 0], ctx->stack[arg2]);
+    ctx->stack[arg3 + 1] = MIN(ctx->stack[arg1 + 1], ctx->stack[arg2]);
+    ctx->stack[arg3 + 2] = MIN(ctx->stack[arg1 + 2], ctx->stack[arg2]);
+    ctx->stack[arg3 + 3] = MIN(ctx->stack[arg1 + 3], ctx->stack[arg2]);
     return LMNT_OK;
 }
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_maxvs(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3 + 0] = fmaxf(ctx->stack[arg1 + 0], ctx->stack[arg2]);
-    ctx->stack[arg3 + 1] = fmaxf(ctx->stack[arg1 + 1], ctx->stack[arg2]);
-    ctx->stack[arg3 + 2] = fmaxf(ctx->stack[arg1 + 2], ctx->stack[arg2]);
-    ctx->stack[arg3 + 3] = fmaxf(ctx->stack[arg1 + 3], ctx->stack[arg2]);
+    ctx->stack[arg3 + 0] = MAX(ctx->stack[arg1 + 0], ctx->stack[arg2]);
+    ctx->stack[arg3 + 1] = MAX(ctx->stack[arg1 + 1], ctx->stack[arg2]);
+    ctx->stack[arg3 + 2] = MAX(ctx->stack[arg1 + 2], ctx->stack[arg2]);
+    ctx->stack[arg3 + 3] = MAX(ctx->stack[arg1 + 3], ctx->stack[arg2]);
     return LMNT_OK;
 }

--- a/LMNT/src/ops_branch.c
+++ b/LMNT/src/ops_branch.c
@@ -22,6 +22,16 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_cmp(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_of
     return LMNT_OK;
 }
 
+LMNT_ATTR_FAST lmnt_result lmnt_op_cmpz(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
+{
+    ctx->status_flags &= ~(LMNT_ISTATUS_CMP_EQ | LMNT_ISTATUS_CMP_LT | LMNT_ISTATUS_CMP_GT | LMNT_ISTATUS_CMP_UN);
+    ctx->status_flags |= (ctx->stack[arg1] == 0.0) * LMNT_ISTATUS_CMP_EQ;
+    ctx->status_flags |= (ctx->stack[arg1] <  0.0) * LMNT_ISTATUS_CMP_LT;
+    ctx->status_flags |= (ctx->stack[arg1] >  0.0) * LMNT_ISTATUS_CMP_GT;
+    ctx->status_flags |= (isnan(ctx->stack[arg1])) * LMNT_ISTATUS_CMP_UN;
+    return LMNT_OK;
+}
+
 LMNT_ATTR_FAST lmnt_result lmnt_op_branch(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
     ctx->cur_instr = LMNT_COMBINE_OFFSET(arg2, arg3);

--- a/LMNT/src/ops_math.c
+++ b/LMNT/src/ops_math.c
@@ -118,7 +118,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_sqrtv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_log(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3] = logf(ctx->stack[arg1]) / logf(ctx->stack[arg2]);
+    ctx->stack[arg3] = ctx->stack[arg2] ? (logf(ctx->stack[arg1]) / logf(ctx->stack[arg2])) : nanf("");
     return LMNT_OK;
 }
 

--- a/LMNT/src/ops_math.c
+++ b/LMNT/src/ops_math.c
@@ -118,7 +118,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_sqrtv(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_log(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    ctx->stack[arg3] = ctx->stack[arg2] ? (logf(ctx->stack[arg1]) / logf(ctx->stack[arg2])) : nanf("");
+    ctx->stack[arg3] = LMNT_LIKELY(ctx->stack[arg2]) ? (logf(ctx->stack[arg1]) / logf(ctx->stack[arg2])) : nanf("");
     return LMNT_OK;
 }
 

--- a/LMNT/src/ops_misc.c
+++ b/LMNT/src/ops_misc.c
@@ -142,7 +142,7 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_dseclen(lmnt_ictx* ctx, lmnt_offset arg1, lmn
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexris(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    if (isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1])) return LMNT_ERROR_ACCESS_VIOLATION;
+    if (LMNT_UNLIKELY(isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1]))) return LMNT_ERROR_ACCESS_VIOLATION;
     size_t arg1v = value_to_size_t(ctx->stack[arg1]);
     if (arg1v + arg2 >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;
     ctx->stack[arg3] = ctx->stack[arg1v + arg2];
@@ -151,8 +151,8 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_indexris(lmnt_ictx* ctx, lmnt_offset arg1, lm
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_indexrir(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-    if (isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1])) return LMNT_ERROR_ACCESS_VIOLATION;
-    if (isnan(ctx->stack[arg3]) || isinf(ctx->stack[arg3])) return LMNT_ERROR_ACCESS_VIOLATION;
+    if (LMNT_UNLIKELY(isnan(ctx->stack[arg1]) || isinf(ctx->stack[arg1]))) return LMNT_ERROR_ACCESS_VIOLATION;
+    if (LMNT_UNLIKELY(isnan(ctx->stack[arg3]) || isinf(ctx->stack[arg3]))) return LMNT_ERROR_ACCESS_VIOLATION;
     size_t arg1v = value_to_size_t(ctx->stack[arg1]);
     size_t arg3v = value_to_size_t(ctx->stack[arg3]);
     if (arg1v + arg2 >= ctx->cur_stack_count || arg3v >= ctx->cur_stack_count) return LMNT_ERROR_ACCESS_VIOLATION;

--- a/LMNT/src/validation.c
+++ b/LMNT/src/validation.c
@@ -138,7 +138,8 @@ static inline lmnt_validation_result validate_operand_codeptr(const lmnt_archive
 {
     const lmnt_loffset target_offset = LMNT_COMBINE_OFFSET(arglo, arghi);
     const lmnt_code* code = validated_get_code(archive, def->code);
-    return (target_offset < code->instructions_count) ? LMNT_VALIDATION_OK : LMNT_VERROR_ACCESS_VIOLATION;
+    // allow a target offset to be "one off the end" to signal branching to end-of-function
+    return (target_offset <= code->instructions_count) ? LMNT_VALIDATION_OK : LMNT_VERROR_ACCESS_VIOLATION;
 }
 
 static lmnt_validation_result validate_instruction(const lmnt_archive* archive, const lmnt_def* def, lmnt_opcode code, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3, size_t constants_count, size_t rw_stack_count, lmnt_offset* defstack, size_t defstack_count)
@@ -285,6 +286,9 @@ static lmnt_validation_result validate_instruction(const lmnt_archive* archive, 
     case LMNT_OP_CMP:
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
         LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg2, 1, constants_count, rw_stack_count));
+        return LMNT_VALIDATION_OK;
+    case LMNT_OP_CMPZ:
+        LMNT_V_OK_OR_RETURN(validate_operand_stack_read(archive, def, arg1, 1, constants_count, rw_stack_count));
         return LMNT_VALIDATION_OK;
     case LMNT_OP_BRANCHZ:
     case LMNT_OP_BRANCHNZ:

--- a/LMNT/test/test_branch.h
+++ b/LMNT/test/test_branch.h
@@ -29,6 +29,24 @@ static void test_branch(void)
 
     TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 
+
+    // test "one past the end" branch
+    a = create_archive_array("test", 0, 1, 1, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x03, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCH,    0x00, 0x05, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x00)
+    );
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 3.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+
+
     a = create_archive_array("test", 0, 1, 1, 16, 0, 0,
         LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0xFF, 0x00, 0x00),
         LMNT_OP_BYTES(LMNT_OP_BRANCH,    0x00, 0x0C, 0x00),
@@ -57,7 +75,7 @@ static void test_branch(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 0, 0, 0, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCH,    0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCH,    0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -113,7 +131,7 @@ static void test_branchceq(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCEQ,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCEQ,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -169,7 +187,7 @@ static void test_branchcne(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCNE,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCNE,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -233,7 +251,7 @@ static void test_branchclt(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -297,7 +315,7 @@ static void test_branchcle(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCLE,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLE,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -361,7 +379,7 @@ static void test_branchcgt(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCGT,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCGT,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -425,7 +443,7 @@ static void test_branchcge(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCGE,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCGE,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -481,7 +499,7 @@ static void test_branchcun(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHCUN,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCUN,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -533,7 +551,7 @@ static void test_branchz(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHZ,    0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHZ,    0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -585,7 +603,7 @@ static void test_branchnz(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHNZ,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHNZ,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -645,7 +663,7 @@ static void test_branchpos(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHPOS,  0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHPOS,  0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -705,7 +723,7 @@ static void test_branchneg(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHNEG,  0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHNEG,  0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
@@ -765,11 +783,295 @@ static void test_branchun(void)
 
     // TODO: separate into "invalid" test suite
     a = create_archive_array("test", 1, 0, 1, 1, 0, 0,
-        LMNT_OP_BYTES(LMNT_OP_BRANCHUN,   0x00, 0x01, 0x00)
+        LMNT_OP_BYTES(LMNT_OP_BRANCHUN,   0x00, 0x02, 0x00)
     );
 
     TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_ACCESS_VIOLATION);
     delete_archive_array(a);
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+
+
+static void test_branchceq_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCEQ, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.2f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_branchcne_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCNE, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.1f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_branchclt_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.01f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_branchcle_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLE, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.3f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.3f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_branchcgt_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCGT, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -3.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+static void test_branchcge_cmpz(void)
+{
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    archive a = create_archive_array("test", 1, 1, 2, 5, 0, 0,
+        LMNT_OP_BYTES(LMNT_OP_CMPZ,      0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCGE, 0x00, 0x04, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x01, 0x00, 0x01),
+        LMNT_OP_BYTES(LMNT_OP_RETURN,    0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x05, 0x00, 0x01)
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 1.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -3.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 5.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, -INFINITY);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, nanf(""));
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 1.0, FLOAT_ERROR_MARGIN);
+
     TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
 }
 
@@ -788,5 +1090,11 @@ MAKE_REGISTER_SUITE_FUNCTION(branch,
     CUNIT_CI_TEST(test_branchnz),
     CUNIT_CI_TEST(test_branchpos),
     CUNIT_CI_TEST(test_branchneg),
-    CUNIT_CI_TEST(test_branchun)
+    CUNIT_CI_TEST(test_branchun),
+    CUNIT_CI_TEST(test_branchceq_cmpz),
+    CUNIT_CI_TEST(test_branchcne_cmpz),
+    CUNIT_CI_TEST(test_branchclt_cmpz),
+    CUNIT_CI_TEST(test_branchcle_cmpz),
+    CUNIT_CI_TEST(test_branchcgt_cmpz),
+    CUNIT_CI_TEST(test_branchcge_cmpz)
 );

--- a/LMNT/test/test_maths_scalar.h
+++ b/LMNT/test/test_maths_scalar.h
@@ -403,6 +403,20 @@ static void test_log(void)
     CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
     CU_ASSERT_DOUBLE_EQUAL(rvals[0], 0.0, FLOAT_ERROR_MARGIN);
 
+    // Zero
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 10.0f, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 10.0f, -0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 3.0f, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_TRUE(isnan(rvals[0]));
+
     // NaN / inf
 
     TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f, 5.0f);

--- a/Laboratory/libelement_cli_lmnt.runsettings
+++ b/Laboratory/libelement_cli_lmnt.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Parameters used by tests at runtime -->
+  <TestRunParameters>
+    <Parameter name="name" value="libelement_cli" />
+    <Parameter name="build-command" value="cmake -S ./libelement.CLI -B ./libelement.CLI/build -DELEMENT_LOG_VERBOSITY=&quot;log_flags::none&quot;" />
+    <Parameter name="additional-build-command" value="cmake --build ./libelement.CLI/build --config Debug" />
+    <Parameter name="executable-path" value="libelement.CLI/build/Debug/element_cli" />
+    <Parameter name="working-directory"  value="libelement.CLI/build/Debug" />
+    <Parameter name="executable-extra-args" value="--target lmnt" />
+  </TestRunParameters>
+</RunSettings>

--- a/libelement.CLI/CMakeLists.txt
+++ b/libelement.CLI/CMakeLists.txt
@@ -57,9 +57,9 @@ add_custom_command(
 target_include_directories(${CMAKE_PROJECT_NAME}
     PUBLIC
         "${CMAKE_CURRENT_SOURCE_DIR}/include"
-        "${element_SOURCE_DIR}/src"
     PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src"
+        "${element_SOURCE_DIR}/src"
 )
 
 if (ELEMENT_FORCE_FALLBACK_FS)
@@ -69,6 +69,7 @@ endif()
 target_link_libraries(${CMAKE_PROJECT_NAME}
     PRIVATE
         element
+        lmnt
         CLI11::CLI11
         fmt::fmt-header-only
         toml11::toml11

--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <element/element.h>
-#include <../../libelement/src/interpreter_internal.hpp>
+#include <interpreter_internal.hpp>
 
 #include "command.hpp"
 #include "compiler_message.hpp"
+
+#include "lmnt/opcodes.h"
+#include "lmnt/archive.h"
+#include "lmnt/interpreter.h"
+#include "lmnt/compiler.hpp"
+#include "lmnt/jit.h"
 
 namespace libelement::cli
 {
@@ -25,8 +31,6 @@ namespace libelement::cli
 
     class evaluate_command final : public command
     {
-        evaluate_command_arguments custom_arguments;
-
     public:
         evaluate_command(common_command_arguments common_arguments,
                          evaluate_command_arguments custom_arguments)
@@ -143,16 +147,36 @@ namespace libelement::cli
             result = element_interpreter_evaluate_instruction(context, evaluator, result_instruction, &input, &output);
             element_evaluator_delete(&evaluator);
 
-            context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
+            std::string interpreter_result_string = fmt::format("Element: {} -> {{", custom_arguments.expression + custom_arguments.arguments);
+            for (int i = 0; i < output.count - 1; ++i)
+            {
+                interpreter_result_string += fmt::format("{}, ", output.values[i]);
+            }
+            interpreter_result_string += fmt::format("{}}}\n", output.values[output.count - 1]);
+            std::cout << interpreter_result_string;
 
             if (result != ELEMENT_OK)
             {
                 return compiler_message(error_conversion(result),
-                                        "Failed to evaluate: " + expression + " called with " + custom_arguments.arguments + " at compile-time with element_result " + std::to_string(result),
-                                        compilation_input.get_log_json());
+                    fmt::format("Failed to evaluate: '{}' called with '{}' at compile-time with element_result '{}'",
+                        expression, custom_arguments.arguments, result),
+                    compilation_input.get_log_json());
             }
 
-            return generate_response(result, output, compilation_input.get_log_json());
+            auto response = generate_response(ELEMENT_ERROR_UNKNOWN, element_outputs{}, compilation_input.get_log_json());
+
+            if (common_arguments.target == Target::Interpreter)
+                response = generate_response(result, output, compilation_input.get_log_json());
+            
+            if (common_arguments.target == Target::LMNT)
+                response = execute_lmnt(compilation_input, result_instruction, input, output, false);
+
+            if (common_arguments.target == Target::LMNTJit)
+                response = execute_lmnt(compilation_input, result_instruction, input, output, true);
+            
+            context->global_scope->remove_declaration(element::identifier{ "<REMOVE>" }, context->caches);
+
+            return response;
         }
 
         [[nodiscard]] compiler_message execute_runtime(const compilation_input& compilation_input) const
@@ -208,9 +232,29 @@ namespace libelement::cli
             element_evaluator_create(context, &evaluator);
             element_interpreter_evaluate_instruction(context, evaluator, compiled_function, &input, &output);
             element_evaluator_delete(&evaluator);
+            
+            std::string interpreter_result_string = fmt::format("Element: {} -> {{", custom_arguments.expression + custom_arguments.arguments);
+            for (int i = 0; i < output.count - 1; ++i)
+            {
+                interpreter_result_string += fmt::format("{}, ", output.values[i]);
+            }
+            interpreter_result_string += fmt::format("{}}}\n", output.values[output.count - 1]);
+            std::cout << interpreter_result_string;
+
+            auto response = generate_response(ELEMENT_ERROR_UNKNOWN, element_outputs{}, compilation_input.get_log_json());
+
+            if (common_arguments.target == Target::Interpreter)
+                response = generate_response(result, output, compilation_input.get_log_json());
+            
+            if (common_arguments.target == Target::LMNT)
+                response = execute_lmnt(compilation_input, compiled_function, input, output, false);
+
+            if (common_arguments.target == Target::LMNTJit)
+                response = execute_lmnt(compilation_input, compiled_function, input, output, true);
+            
             element_instruction_delete(&compiled_function);
 
-            return generate_response(result, output, compilation_input.get_log_json());
+            return response;
         }
 
         [[nodiscard]] std::string as_string() const override
@@ -240,5 +284,196 @@ namespace libelement::cli
                 callback(cmd);
             });
         }
+
+    private:
+        static std::vector<char> create_archive(
+            const char* def_name,
+            uint16_t args_count,
+            uint16_t rvals_count,
+            uint16_t stack_count,
+            const std::vector<lmnt_value>& constants,
+            const std::vector<lmnt_instruction>& function)
+        {
+            const size_t name_len = strlen(def_name);
+            const size_t name_len_padded = LMNT_ROUND_UP(0x02 + name_len + 1, 4) - 2;
+            const size_t instr_count = function.size();
+            const size_t consts_count = constants.size();
+            const size_t data_count = 0;
+            assert(name_len_padded <= 0xFD);
+            assert(instr_count <= 0x3FFFFFF0);
+            assert(consts_count <= 0x3FFFFFFF);
+
+            const size_t header_len = 0x1C;
+            const size_t strings_len = 0x02 + name_len_padded;
+            const size_t defs_len = 0x10;
+            const size_t code_len = 0x04 + instr_count * sizeof(lmnt_instruction);
+            const lmnt_loffset data_sec_count = 0;
+            const size_t data_len = 0x04 + data_sec_count * (0x08 + 0x04 * data_count);
+            const size_t consts_len = consts_count * sizeof(lmnt_value);
+
+            const size_t total_size = header_len + strings_len + defs_len + code_len + data_len + consts_len;
+            std::vector<char> buf;
+            buf.resize(total_size);
+
+            size_t idx = 0;
+            const char header[] = {
+                'L', 'M', 'N', 'T',
+                0x00, 0x00, 0x00, 0x00,
+                char(strings_len & 0xFF), char((strings_len >> 8) & 0xFF), char((strings_len >> 16) & 0xFF), char((strings_len >> 24) & 0xFF), // strings length
+                char(defs_len & 0xFF), char((defs_len >> 8) & 0xFF), char((defs_len >> 16) & 0xFF), char((defs_len >> 24) & 0xFF),             // defs length
+                char(code_len & 0xFF), char((code_len >> 8) & 0xFF), char((code_len >> 16) & 0xFF), char((code_len >> 24) & 0xFF),             // code length
+                char(data_len & 0xFF), char((data_len >> 8) & 0xFF), char((data_len >> 16) & 0xFF), char((data_len >> 24) & 0xFF),             // data length
+                char(consts_len & 0xFF), char((consts_len >> 8) & 0xFF), char((consts_len >> 16) & 0xFF), char((consts_len >> 24) & 0xFF)      // constants_length
+            };
+            memcpy(buf.data() + idx, header, sizeof(header));
+            idx += sizeof(header);
+
+            buf[idx] = name_len_padded & 0xFF;
+            idx += 2;
+
+            memcpy(buf.data() + idx, def_name, name_len);
+            idx += name_len;
+            for (size_t i = name_len; i < name_len_padded; ++i)
+                buf[idx++] = '\0';
+
+            const char def[] = {
+                0x00, 0x00,                                    // defs[0].name
+                0x00, 0x00,                                    // defs[0].flags
+                0x00, 0x00, 0x00, 0x00,                        // defs[0].code
+                stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_unaligned
+                stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_aligned
+                args_count & 0xFF, (args_count >> 8) & 0xFF,   // defs[0].args_count
+                rvals_count & 0xFF, (rvals_count >> 8) & 0xFF, // defs[0].rvals_count
+            };
+            memcpy(buf.data() + idx, def, sizeof(def));
+            idx += sizeof(def);
+
+            memcpy(buf.data() + idx, (const char*)(&instr_count), sizeof(uint32_t));
+            idx += sizeof(uint32_t);
+
+            memcpy(buf.data() + idx, function.data(), instr_count * sizeof(lmnt_instruction));
+            idx += instr_count * sizeof(lmnt_instruction);
+
+            memcpy(buf.data() + idx, (const char*)(&data_sec_count), sizeof(lmnt_loffset));
+            idx += sizeof(lmnt_loffset);
+
+            memcpy(buf.data() + idx, constants.data(), consts_count * sizeof(lmnt_value));
+            idx += consts_count * sizeof(lmnt_value);
+
+            assert(idx == total_size);
+
+            return buf;
+        }
+
+        compiler_message execute_lmnt(
+            const compilation_input& compilation_input,
+            element_instruction* instruction,
+            element_inputs input,
+            element_outputs output,
+            bool jit) const
+        {
+            std::vector<lmnt_value> lmnt_results;
+            
+            element_lmnt_compiler_ctx lmnt_ctx;
+            element_lmnt_compiled_function lmnt_output;
+            std::vector<element_value> constants;
+            lmnt_result lresult = LMNT_OK;
+            lmnt_validation_result lvresult = LMNT_VALIDATION_OK;
+            const char* loperation = "nothing ecksdee";
+
+            auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, constants, input.count, lmnt_output);
+            if (result != ELEMENT_OK)
+            {
+                printf("RUH ROH: %d\n", result);
+                goto cleanup;
+            }
+
+            for (const auto& in : lmnt_output.instructions)
+            {
+                printf("Instruction: %s %04X %04X %04X\n", lmnt_get_opcode_info(in.opcode)->name, in.arg1, in.arg2, in.arg3);
+            }
+
+            {
+                auto lmnt_archive_data = create_archive("evaluate", uint16_t(input.count), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions);
+
+                std::vector<char> lmnt_stack(32768);
+                lmnt_ictx lctx;
+                lmnt_result lresult = LMNT_OK;
+
+                loperation = "init";
+                lresult = lmnt_init(&lctx, lmnt_stack.data(), lmnt_stack.size());
+                if (lresult != LMNT_OK)
+                    goto lmnt_error;
+                    
+                loperation = "archive load";
+                lresult = lmnt_load_archive(&lctx, lmnt_archive_data.data(), lmnt_archive_data.size());
+                if (lresult != LMNT_OK)
+                    goto lmnt_error;
+
+                loperation = "archive prepare";
+                lresult = lmnt_prepare_archive(&lctx, &lvresult);
+                if (lresult != LMNT_OK)
+                {
+                    printf("LMNT validation error: %d\n", lvresult);
+                    goto lmnt_error;
+                }
+
+                loperation = "def search";
+                const lmnt_def* def = nullptr;
+                lresult = lmnt_find_def(&lctx, "evaluate", &def);
+                if (lresult != LMNT_OK)
+                    goto lmnt_error;
+
+                loperation = "setting args";
+                lresult = lmnt_update_args(&lctx, def, 0, input.values, lmnt_offset(input.count));
+                if (lresult != LMNT_OK)
+                    goto lmnt_error;
+
+                loperation = "executing def";
+                lmnt_results.resize(output.count);
+                lresult = lmnt_execute(&lctx, def, lmnt_results.data(), lmnt_offset(lmnt_results.size()));
+                if (lresult != lmnt_results.size())
+                    goto lmnt_error;
+
+                for (size_t i = 0; i < lmnt_results.size(); ++i)
+                    printf("lmnt_results[%zu]: %f\n", i, lmnt_results[i]);
+                
+                if (jit)
+                {
+                    lmnt_results.resize(output.count);
+                    
+                    loperation = "jit compile";
+                    lmnt_jit_fn_data fndata;
+                    lresult = lmnt_jit_compile(&lctx, def, LMNT_JIT_TARGET_CURRENT, &fndata);
+                    if (lresult != LMNT_OK)
+                        goto lmnt_error;
+
+                    loperation = "jit execute";
+                    lmnt_results.resize(output.count);
+                    lresult = lmnt_jit_execute(&lctx, def, &fndata, lmnt_results.data(), lmnt_offset(lmnt_results.size()));
+                    if (lresult != lmnt_results.size())
+                        goto lmnt_error;
+
+                    for (size_t i = 0; i < lmnt_results.size(); ++i)
+                        printf("lmnt_jit_results[%zu]: %f\n", i, lmnt_results[i]);
+                }
+            }
+
+        lmnt_error:
+            if (lresult != LMNT_OK)
+            {
+                printf("LMNT ERROR during %s: %d\n", loperation, lresult);
+                result = ELEMENT_ERROR_UNKNOWN;
+            }
+
+        cleanup:
+            element_outputs lmnt_outputs;
+            lmnt_outputs.count = lmnt_results.size();
+            lmnt_outputs.values = lmnt_results.data();
+
+            return generate_response(result, lmnt_outputs, compilation_input.get_log_json());
+        }
+
+        evaluate_command_arguments custom_arguments;
     };
 } // namespace libelement::cli

--- a/libelement.CLI/src/command.cpp
+++ b/libelement.CLI/src/command.cpp
@@ -30,6 +30,9 @@ void command::configure(CLI::App& app, command::callback callback)
                  "parse trace if parsing fails.");
     app.add_flag("--interpreted", arguments->compiletime,
                  "");
+    app.add_option("--target", arguments->target,
+                   "Target to execute. default is 'interpreter'. must be one of 'interpreter', 'lmnt', or 'lmnt-jit'")
+        ->transform(CLI::CheckedTransformer(arguments->target_mapping, CLI::ignore_case));
 
     // not a big fan of this but it works, so leaving it for now
     parse_command::configure(app, arguments, callback);

--- a/libelement.CLI/src/main.cpp
+++ b/libelement.CLI/src/main.cpp
@@ -83,14 +83,15 @@ void command_callback(command& command)
 
 int main(const int argc, char** argv)
 {
-    /*#if !defined(NDEBUG) && defined(WIN32)
+    #if !defined(NDEBUG)
     std::string args;
     for (int i = 0; i < argc; ++i)
     {
         args += argv[i];
+        args += " ";
     }
-    std::cout << args << " " << std::endl;
-    #endif*/
+    std::cout << "Raw CLI Arguments: " << args << std::endl << std::endl;
+    #endif
     
     // parse arguments and construct exactly one required command
     CLI::App app{ "CLI interface for libelement" };

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -274,6 +274,10 @@ if (UNIX AND NOT APPLE)
     target_link_libraries(element PRIVATE "m" "atomic" "pthread" "stdc++fs")
 endif ()
 
+# TODO: this, nicer
+add_subdirectory("${CMAKE_SOURCE_DIR}/../LMNT" "${CMAKE_BINARY_DIR}/lmnt" EXCLUDE_FROM_ALL)
+target_link_libraries(element PRIVATE lmnt)
+
 ## A C project to ensure our C API is correct
 add_executable(element_app_c "${CMAKE_CURRENT_SOURCE_DIR}/test/main.c")
 target_link_libraries(element_app_c PRIVATE element)
@@ -298,7 +302,7 @@ if (ELEMENT_BUILD_TESTING)
             )
 
     add_executable(element_tests ${TEST_SOURCES})
-    target_link_libraries(element_tests PRIVATE Catch2 element)
+    target_link_libraries(element_tests PRIVATE Catch2 element lmnt)
     if (NOT ELEMENT_USE_EXTERNAL_FMT)
         target_link_libraries(element_tests PRIVATE fmt::fmt-header-only)
     endif ()
@@ -342,6 +346,18 @@ if (ELEMENT_BUILD_TESTING)
             message(WARNING "Lcov not found, coverage report not generated for libelement test app.")
         endif()
     endif()
+
+    # TODO: remove this, make it part of Catch tests
+    add_executable(element_lmnt_testapp "test/lmnt_test.cpp")
+    target_link_libraries(element_lmnt_testapp PRIVATE element lmnt)
+    target_include_directories(element_lmnt_testapp PRIVATE "${element_SOURCE_DIR}/src" "${CMAKE_BINARY_DIR}/_deps/fmt-src/include")
+    set_target_properties(element_lmnt_testapp PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${debug_dir}")
+    # Copy prelude alongside built library
+    add_custom_command (
+            TARGET element_lmnt_testapp POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/../ContentFiles"
+            "${debug_dir}")
 endif()
 
 find_program(CLANG_FORMAT clang-format)

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -198,6 +198,8 @@ set(element_sources
     #LMNT
     "src/lmnt/compiler.cpp"
     "src/lmnt/compiler.hpp"
+    "src/lmnt/compiler_state.cpp"
+    "src/lmnt/compiler_state.hpp"
 
     #Util
     "src/stringutil.hpp"

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -195,6 +195,10 @@ set(element_sources
     "src/instruction_tree/fwd.hpp"
     "src/instruction_tree/cache.hpp"
 
+    #LMNT
+    "src/lmnt/compiler.cpp"
+    "src/lmnt/compiler.hpp"
+
     #Util
     "src/stringutil.hpp"
     "src/typeutil.hpp"

--- a/libelement/src/instruction_tree/instructions.cpp
+++ b/libelement/src/instruction_tree/instructions.cpp
@@ -74,8 +74,9 @@ instruction_if::instruction_if(instruction_const_shared_ptr predicate, instructi
     m_dependents.emplace_back(std::move(if_false));
 }
 
-instruction_for::instruction_for(instruction_const_shared_ptr initial, instruction_const_shared_ptr condition, instruction_const_shared_ptr body)
+instruction_for::instruction_for(instruction_const_shared_ptr initial, instruction_const_shared_ptr condition, instruction_const_shared_ptr body, std::set<std::shared_ptr<const instruction_input>> inputs)
     : instruction(type_id, nullptr)
+    , inputs(std::move(inputs))
 {
     actual_type = initial->actual_type;
 

--- a/libelement/src/instruction_tree/instructions.hpp
+++ b/libelement/src/instruction_tree/instructions.hpp
@@ -1,17 +1,19 @@
 #pragma once
 
-#include <string>
-#include <vector>
-#include <utility>
-#include <numeric>
-#include <unordered_map>
-
 #include "../ast/ast_internal.hpp"
 #include "../ast/fwd.hpp"
 #include "instruction_tree/fwd.hpp"
 #include "typeutil.hpp"
 #include "object_model/constraints/type.hpp"
 #include "object_model/object_internal.hpp"
+
+//STD
+#include <string>
+#include <vector>
+#include <utility>
+#include <numeric>
+#include <unordered_map>
+#include <set>
 
 namespace element
 {
@@ -244,12 +246,23 @@ namespace element
     {
         DECLARE_TYPE_ID();
 
-        explicit instruction_for(instruction_const_shared_ptr initial, instruction_const_shared_ptr condition, instruction_const_shared_ptr body);
+        explicit instruction_for(instruction_const_shared_ptr initial, instruction_const_shared_ptr condition, instruction_const_shared_ptr body, std::set<std::shared_ptr<const instruction_input>> inputs);
         [[nodiscard]] const instruction_const_shared_ptr& initial() const { return m_dependents[0]; }
         [[nodiscard]] const instruction_const_shared_ptr& condition() const { return m_dependents[1]; }
         [[nodiscard]] const instruction_const_shared_ptr& body() const { return m_dependents[2]; }
 
         [[nodiscard]] size_t get_size() const override { return m_dependents[0]->get_size(); }
+
+        [[nodiscard]] bool is_input(const instruction_input& input) const
+        {
+            const auto it = std::find_if(inputs.begin(), inputs.end(), [&input](const auto& our_input) {
+                return &input == our_input.get();
+            });
+
+            return it != inputs.end();
+        }
+
+        std::set<std::shared_ptr<const instruction_input>> inputs;
     };
 
     struct instruction_fold final : public instruction

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -655,7 +655,7 @@ element_result element_interpreter_evaluate_call_expression(
             return eval_result;
     }
 
-    int serialised_size = 0;
+    size_t serialised_size = 0;
     for (const auto& arg : serialised_arguments)
         serialised_size += static_cast<int>(arg.size());
 

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -18,7 +18,7 @@ element_result prepare_virtual_result(
     compiler_state& state,
     const element::instruction* expr);
 
-element_result optimise_virtual_result(
+element_result allocate_virtual_result(
     compiler_state& state,
     const element::instruction* expr);
 
@@ -77,7 +77,7 @@ static element_result prepare_virtual_constant(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_constant(
+static element_result allocate_virtual_constant(
     compiler_state& state,
     const element::instruction_constant& ec,
     virtual_result& vr)
@@ -145,7 +145,7 @@ static element_result prepare_virtual_input(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_input(
+static element_result allocate_virtual_input(
     compiler_state& state,
     const element::instruction_input& ei,
     virtual_result& vr)
@@ -208,7 +208,7 @@ static element_result prepare_virtual_serialised_structure(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_serialised_structure(
+static element_result allocate_virtual_serialised_structure(
     compiler_state& state,
     const element::instruction_serialised_structure& es,
     virtual_result& vr)
@@ -256,7 +256,7 @@ static element_result prepare_virtual_nullary(
     return state.set_allocation_if_not_pinned(&en, 1);
 }
 
-static element_result optimise_virtual_nullary(
+static element_result allocate_virtual_nullary(
     compiler_state& state,
     const element::instruction_nullary& en,
     virtual_result& vr)
@@ -339,7 +339,7 @@ static element_result prepare_virtual_unary(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_unary(
+static element_result allocate_virtual_unary(
     compiler_state& state,
     const element::instruction_unary& eu,
     virtual_result& vr)
@@ -436,7 +436,7 @@ static element_result prepare_virtual_binary(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_binary(
+static element_result allocate_virtual_binary(
     compiler_state& state,
     const element::instruction_binary& eb,
     virtual_result& vr)
@@ -588,7 +588,7 @@ static element_result prepare_virtual_if(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_if(
+static element_result allocate_virtual_if(
     compiler_state& state,
     const element::instruction_if& ei,
     virtual_result& vr)
@@ -689,7 +689,7 @@ static element_result prepare_virtual_for(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_for(
+static element_result allocate_virtual_for(
     compiler_state& state,
     const element::instruction_for& ef,
     virtual_result& vr)
@@ -773,7 +773,7 @@ static element_result prepare_virtual_indexer(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_indexer(
+static element_result allocate_virtual_indexer(
     compiler_state& state,
     const element::instruction_indexer& ei,
     virtual_result& vr)
@@ -854,7 +854,7 @@ static element_result prepare_virtual_select(
     return ELEMENT_OK;
 }
 
-static element_result optimise_virtual_select(
+static element_result allocate_virtual_select(
     compiler_state& state,
     const element::instruction_select& es,
     virtual_result& vr)
@@ -1034,7 +1034,7 @@ static element_result prepare_virtual_result(
 }
 
 
-static element_result optimise_virtual_result(
+static element_result allocate_virtual_result(
     compiler_state& state,
     const element::instruction* expr)
 {
@@ -1048,34 +1048,34 @@ static element_result optimise_virtual_result(
     element_result oresult = ELEMENT_ERROR_NO_IMPL;
 
     if (const auto* ec = expr->as<element::instruction_constant>())
-        oresult = optimise_virtual_constant(state, *ec, vr);
+        oresult = allocate_virtual_constant(state, *ec, vr);
 
     if (const auto* ei = expr->as<element::instruction_input>())
-        oresult = optimise_virtual_input(state, *ei, vr);
+        oresult = allocate_virtual_input(state, *ei, vr);
 
     if (const auto* es = expr->as<element::instruction_serialised_structure>())
-        oresult = optimise_virtual_serialised_structure(state, *es, vr);
+        oresult = allocate_virtual_serialised_structure(state, *es, vr);
 
     if (const auto* en = expr->as<element::instruction_nullary>())
-        oresult = optimise_virtual_nullary(state, *en, vr);
+        oresult = allocate_virtual_nullary(state, *en, vr);
 
     if (const auto* eu = expr->as<element::instruction_unary>())
-        oresult = optimise_virtual_unary(state, *eu, vr);
+        oresult = allocate_virtual_unary(state, *eu, vr);
 
     if (const auto* eb = expr->as<element::instruction_binary>())
-        oresult = optimise_virtual_binary(state, *eb, vr);
+        oresult = allocate_virtual_binary(state, *eb, vr);
 
     if (const auto* ei = expr->as<element::instruction_if>())
-        oresult = optimise_virtual_if(state, *ei, vr);
+        oresult = allocate_virtual_if(state, *ei, vr);
 
     if (const auto* ef = expr->as<element::instruction_for>())
-        oresult = optimise_virtual_for(state, *ef, vr);
+        oresult = allocate_virtual_for(state, *ef, vr);
 
     if (const auto* ei = expr->as<element::instruction_indexer>())
-        oresult = optimise_virtual_indexer(state, *ei, vr);
+        oresult = allocate_virtual_indexer(state, *ei, vr);
 
     if (const auto* sel = expr->as<element::instruction_select>())
-        oresult = optimise_virtual_select(state, *sel, vr);
+        oresult = allocate_virtual_select(state, *sel, vr);
 
     if (oresult == ELEMENT_OK)
         vr.prepared = true;
@@ -1167,7 +1167,7 @@ element_result element_lmnt_compile_function(
     ELEMENT_OK_OR_RETURN(state.use_pinned_allocation(instruction.get(), allocation_type::output, 0, vr.count));
     // continue with compilation
     ELEMENT_OK_OR_RETURN(prepare_virtual_result(state, instruction.get()));
-    ELEMENT_OK_OR_RETURN(optimise_virtual_result(state, instruction.get()));
+    ELEMENT_OK_OR_RETURN(allocate_virtual_result(state, instruction.get()));
     ELEMENT_OK_OR_RETURN(compile_instruction(state, instruction.get(), output.instructions));
     output.inputs_count = inputs_count;
     ELEMENT_OK_OR_RETURN(state.find_virtual_result(instruction.get(), vr));

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -949,7 +949,7 @@ static element_result create_virtual_result(
     virtual_result& result)
 {
     // CSE
-    if (auto it = state.results.find(expr); it != state.results.end())
+    if (auto it = state.inst_indices.find(expr); it != state.inst_indices.end())
     {
         result = state.virtual_results[it->second];
         return ELEMENT_OK;
@@ -990,7 +990,7 @@ static element_result create_virtual_result(
     if (oresult == ELEMENT_OK)
     {
         result.stage = compilation_stage::created;
-        state.results.emplace(expr, state.virtual_results.size());
+        state.inst_indices.emplace(expr, state.virtual_results.size());
         state.virtual_results.emplace_back(result);
     }
 
@@ -1002,8 +1002,8 @@ static element_result prepare_virtual_result(
     compiler_state& state,
     const element::instruction* expr)
 {
-    auto it = state.results.find(expr);
-    if (it == state.results.end()) return ELEMENT_ERROR_NOT_FOUND;
+    auto it = state.inst_indices.find(expr);
+    if (it == state.inst_indices.end()) return ELEMENT_ERROR_NOT_FOUND;
 
     virtual_result& vr = state.virtual_results[it->second];
     if (vr.stage >= compilation_stage::prepared)
@@ -1052,8 +1052,8 @@ static element_result allocate_virtual_result(
     compiler_state& state,
     const element::instruction* expr)
 {
-    auto it = state.results.find(expr);
-    if (it == state.results.end()) return ELEMENT_ERROR_NOT_FOUND;
+    auto it = state.inst_indices.find(expr);
+    if (it == state.inst_indices.end()) return ELEMENT_ERROR_NOT_FOUND;
 
     virtual_result& vr = state.virtual_results[it->second];
     if (vr.stage >= compilation_stage::allocated)
@@ -1103,8 +1103,8 @@ static element_result compile_instruction(
     const element::instruction* expr,
     std::vector<lmnt_instruction>& output)
 {
-    auto results_it = state.results.find(expr);
-    if (results_it == state.results.end())
+    auto results_it = state.inst_indices.find(expr);
+    if (results_it == state.inst_indices.end())
         return ELEMENT_ERROR_UNKNOWN;
 
     virtual_result& vr = state.virtual_results[results_it->second];

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -214,7 +214,6 @@ static element_result prepare_virtual_serialised_structure(
     for (const auto& d : es.dependents())
     {
         ELEMENT_OK_OR_RETURN(prepare_virtual_result(state, d.get()));
-        // this may fail (e.g. if it's pinned), which is fine - we'll just copy it in
         state.allocator->set_parent(d.get(), &es, index);
         state.allocator->use(&es, d.get());
 
@@ -249,8 +248,6 @@ static element_result compile_serialised_structure(
         const stack_allocation* d_vr = state.allocator->get(d.get());
         if (!d_vr)
             return ELEMENT_ERROR_UNKNOWN;
-        if (d_vr->pinned() && d_vr->type() != allocation_type::constant)
-            continue;
 
         uint16_t d_index = state.calculate_stack_index(d_vr->type(), d_vr->index());
         copy_stack_values(d_index, stack_idx + index, d_vr->count, output);

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -748,7 +748,7 @@ static element_result allocate_virtual_indexer(
     compiler_state& state,
     const element::instruction_indexer& ei)
 {
-    // TODO: do we need to allocate the for here?
+    ELEMENT_OK_OR_RETURN(allocate_virtual_result(state, ei.for_instruction().get()));
     return state.allocator->allocate(&ei);
 }
 
@@ -758,6 +758,8 @@ static element_result compile_indexer(
     const uint16_t stack_idx,
     std::vector<lmnt_instruction>& output)
 {
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, ei.for_instruction().get(), output));
+
     uint16_t for_stack_idx;
     ELEMENT_OK_OR_RETURN(state.calculate_stack_index(ei.for_instruction().get(), for_stack_idx));
 
@@ -1075,6 +1077,9 @@ static element_result compile_instruction(
 {
     stack_allocation* vr = state.allocator->get(expr);
     if (!vr) return ELEMENT_ERROR_UNKNOWN;
+
+    if (vr->stage >= compilation_stage::compiled)
+        return ELEMENT_OK;
 
     uint16_t index;
     ELEMENT_OK_OR_RETURN(state.calculate_stack_index(expr, index));

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -1,0 +1,830 @@
+#include "lmnt/compiler.hpp"
+
+#include <algorithm>
+#include <vector>
+#include <unordered_map>
+
+#define U16_LO(x) static_cast<uint16_t>((x) & 0xFFFF)
+#define U16_HI(x) static_cast<uint16_t>(((x) >> 16) & 0xFFFF)
+
+struct virtual_result
+{
+    const element::instruction* instruction = nullptr;
+    uint16_t count = 0;
+    // filled in during compilation process
+    uint16_t stack_index = 0;
+    size_t inst_index_set = 0;
+    size_t inst_index_last_used = 0;
+};
+
+struct compiler_state
+{
+    const element_lmnt_compiler_ctx& ctx;
+    std::vector<element_value> constants;
+    uint16_t inputs_count;
+
+    std::unordered_map<const element::instruction*, size_t> results;
+    std::vector<virtual_result> virtual_results;
+
+    element_result add_constant(element_value value)
+    {
+        if (constants.size() >= UINT16_MAX)
+            return ELEMENT_ERROR_UNKNOWN;
+        if (std::find(constants.begin(), constants.end(), value) == constants.end())
+            constants.emplace_back(value);
+        return ELEMENT_OK;
+    }
+
+    element_result find_constant(element_value value, uint16_t& index)
+    {
+        if (auto it = std::find(constants.begin(), constants.end(), value); it != constants.end())
+        {
+            index = static_cast<uint16_t>(std::distance(constants.begin(), it));
+            return ELEMENT_OK;
+        }
+        else
+        {
+            return ELEMENT_ERROR_NOT_FOUND;
+        }
+    }
+
+    element_result find_virtual_result(const element::instruction* in, virtual_result& vr)
+    {
+        if (auto it = results.find(in); it != results.end() && it->second < virtual_results.size())
+        {
+            vr = virtual_results[it->second];
+            return ELEMENT_OK;
+        }
+        else
+        {
+            return ELEMENT_ERROR_NOT_FOUND;
+        }
+    }
+};
+
+
+element_result create_virtual_result(
+    compiler_state& state,
+    const element::instruction* expr,
+    virtual_result& result);
+
+element_result compile_instruction(
+    compiler_state& state,
+    const element::instruction* expr,
+    std::vector<lmnt_instruction>& output);
+
+
+element_result copy_stack_values(const uint16_t src_index, const uint16_t dst_index, const uint16_t count, std::vector<lmnt_instruction>& output)
+{
+    if (src_index == dst_index)
+        return ELEMENT_OK;
+
+    const uint16_t countm4 = (count/4)*4;
+    for (uint16_t i = 0; i < countm4; i += 4)
+        output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNVV, uint16_t(src_index + i), 0, uint16_t(dst_index + i)});
+    for (uint16_t i = countm4; i < count; ++i)
+        output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNSS, uint16_t(src_index + i), 0, uint16_t(dst_index + i)});
+    return ELEMENT_OK;
+}
+
+
+//
+// Constant
+//
+
+static element_result create_virtual_constant(
+    compiler_state& state,
+    const element::instruction_constant& ec,
+    virtual_result& result)
+{
+    result.instruction = &ec;
+    result.count = 1;
+
+    // TODO: constant candidates here?
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_constant_value(
+    compiler_state& state,
+    element_value value,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    uint16_t constant_idx;
+    if (state.find_constant(value, constant_idx) == ELEMENT_OK) {
+        // this constant is present in the "hard" constants list, so we don't need to do anything
+        // output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNSS, constant_idx, 0, output_idx});
+    } else {
+        // encode the constant as part of the instruction
+        uint32_t arg;
+        assert(sizeof(arg) == sizeof(value));
+        std::memcpy(&arg, &value, sizeof(value));
+        const uint16_t arglo = static_cast<uint16_t>(arg & 0xFFFF);
+        const uint16_t arghi = static_cast<uint16_t>((arg >> 16) & 0xFFFF);
+        output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIBS, arglo, arghi, output_idx});
+    }
+    return ELEMENT_OK;
+}
+
+static element_result compile_constant(
+    compiler_state& state,
+    const element::instruction_constant& ec,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    return compile_constant_value(state, ec.value(), output_idx, output);
+}
+
+
+//
+// Input
+//
+
+static element_result create_virtual_input(
+    compiler_state& state,
+    const element::instruction_input& ei,
+    virtual_result& result)
+{
+    result.instruction = &ei;
+    result.count = 1;
+    return ELEMENT_OK;
+}
+
+static element_result compile_input(
+    compiler_state& state,
+    const element::instruction_input& ei,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    // straight copy from input[n] to output[m]
+    copy_stack_values(static_cast<uint16_t>(state.constants.size() + ei.index()), output_idx, 1, output);
+    return ELEMENT_OK;
+}
+
+
+//
+// Serialised structure
+//
+
+static element_result create_virtual_serialised_structure(
+    compiler_state& state,
+    const element::instruction_serialised_structure& es,
+    virtual_result& result)
+{
+    result.instruction = &es;
+    result.count = 0;
+    for (const auto& d : es.dependents())
+    {
+        virtual_result vr;
+        ELEMENT_OK_OR_RETURN(create_virtual_result(state, d.get(), vr));
+        result.count += vr.count;
+    }
+    return ELEMENT_OK;
+}
+
+static element_result compile_serialised_structure(
+    compiler_state& state,
+    const element::instruction_serialised_structure& es,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    for (const auto& d : es.dependents())
+    {
+        ELEMENT_OK_OR_RETURN(compile_instruction(state, d.get(), output));
+    }
+    return ELEMENT_OK;
+}
+
+
+//
+// Nullary
+//
+
+static element_result create_virtual_nullary(
+    compiler_state& state,
+    const element::instruction_nullary& en,
+    virtual_result& result)
+{
+    result.instruction = &en;
+    result.count = 1;
+    return ELEMENT_OK;
+}
+
+static element_result compile_nullary(
+    compiler_state& state,
+    const element::instruction_nullary& en,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    element_value value;
+    switch (en.operation())
+    {
+    //num
+    case element::instruction_nullary::op::positive_infinity:
+        value = std::numeric_limits<float>::infinity(); break;
+    case element::instruction_nullary::op::negative_infinity:
+        value = -std::numeric_limits<float>::infinity(); break;
+    case element::instruction_nullary::op::nan:
+        value = std::numeric_limits<float>::quiet_NaN(); break;
+
+    //boolean
+    case element::instruction_nullary::op::true_value:
+        value = 1; break;
+    case element::instruction_nullary::op::false_value:
+        value = 0; break;
+    default:
+        assert(false);
+        return ELEMENT_ERROR_UNKNOWN;
+    }
+    return compile_constant_value(state, value, output_idx, output);
+}
+
+
+//
+// Unary
+//
+
+static element_result create_virtual_unary(
+    compiler_state& state,
+    const element::instruction_unary& eu,
+    virtual_result& result)
+{
+    result.instruction = &eu;
+    result.count = 1;
+
+    if (eu.dependents().size() != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    virtual_result arg_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, eu.dependents()[0].get(), arg_vr));
+
+    if (arg_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    // if we're doing boolean not we need to bring a couple of constants along
+    if (eu.operation() == element::instruction_unary::op::not_)
+    {
+        ELEMENT_OK_OR_RETURN(state.add_constant(-1));
+        ELEMENT_OK_OR_RETURN(state.add_constant(1));
+    }
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_unary(
+    compiler_state& state,
+    const element::instruction_unary& eu,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    if (eu.dependents().size() != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+    // get the argument and ensure it's only 1 wide
+    virtual_result arg_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(eu.dependents()[0].get(), arg_vr));
+    if (arg_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+    // compile the argument
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, arg_vr.instruction, output));
+
+    if (eu.operation() == element::instruction_unary::op::not_)
+    {
+        // boolean value is defined as >0 being true and <=0 as being false
+        // this requires a bit of creative logic to ensure correctness for all inputs
+        // ceil --> min(1) --> mul(-1) --> add(1)
+        // for x < 0:  ceil --> (x <= 0)  --> min(1) --> no change --> mul(-1) --> (x > 0)   --> add(1) --> (x > 0)
+        // for x == 0: ceil --> no change --> min(1) --> no change --> mul(-1) --> no change --> add(1) --> (x == 1)
+        // for x <= 1: ceil --> (x == 1)  --> min(1) --> no change --> mul(-1) --> (x == -1) --> add(1) --> (x == 0)
+        // for x > 1:  ceil --> (x > 1)   --> min(1) --> (x == 1)  --> mul(-1) --> (x == -1) --> add(1) --> (x == 0)
+        uint16_t const_minus1, const_plus1;
+        ELEMENT_OK_OR_RETURN(state.find_constant(-1, const_minus1));
+        ELEMENT_OK_OR_RETURN(state.find_constant(1, const_plus1));
+        output.emplace_back(lmnt_instruction{LMNT_OP_CEILS, arg_vr.stack_index, 0, output_idx});
+        output.emplace_back(lmnt_instruction{LMNT_OP_MINSS, output_idx, const_plus1, output_idx});
+        output.emplace_back(lmnt_instruction{LMNT_OP_MULSS, output_idx, const_minus1, output_idx});
+        output.emplace_back(lmnt_instruction{LMNT_OP_ADDSS, output_idx, const_plus1, output_idx});
+    }
+    else
+    {
+        lmnt_opcode op;
+        switch (eu.operation())
+        {
+        case element::instruction_unary::op::abs:   op = LMNT_OP_ABSS;   break;
+        case element::instruction_unary::op::acos:  op = LMNT_OP_ACOS;   break;
+        case element::instruction_unary::op::asin:  op = LMNT_OP_ASIN;   break;
+        case element::instruction_unary::op::atan:  op = LMNT_OP_ATAN;   break;
+        case element::instruction_unary::op::ceil:  op = LMNT_OP_CEILS;  break;
+        case element::instruction_unary::op::cos:   op = LMNT_OP_COS;    break;
+        case element::instruction_unary::op::floor: op = LMNT_OP_FLOORS; break;
+        case element::instruction_unary::op::ln:    op = LMNT_OP_LN;     break;
+        case element::instruction_unary::op::sin:   op = LMNT_OP_SIN;    break;
+        case element::instruction_unary::op::tan:   op = LMNT_OP_TAN;    break;
+        default: assert(false); return ELEMENT_ERROR_UNKNOWN;
+        }
+        output.emplace_back(lmnt_instruction{op, arg_vr.stack_index, 0, output_idx});
+    }
+    return ELEMENT_OK;
+}
+
+
+//
+// Binary
+//
+
+static element_result create_virtual_binary(
+    compiler_state& state,
+    const element::instruction_binary& eb,
+    virtual_result& result)
+{
+    result.instruction = &eb;
+    result.count = 1;
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_binary(
+    compiler_state& state,
+    const element::instruction_binary& eb,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    if (eb.dependents().size() != 2)
+        return ELEMENT_ERROR_UNKNOWN;
+    // get the arguments and ensure they're only 1 wide
+    virtual_result arg1_vr, arg2_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(eb.dependents()[0].get(), arg1_vr));
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(eb.dependents()[1].get(), arg2_vr));
+    if (arg1_vr.count != 1 || arg2_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+    // compile the arguments
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, arg1_vr.instruction, output));
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, arg2_vr.instruction, output));
+
+    lmnt_opcode op;
+    switch (eb.operation())
+    {
+        //num
+        case element::instruction_binary::op::add:   op = LMNT_OP_ADDSS; goto num_operation;
+        case element::instruction_binary::op::atan2: op = LMNT_OP_ATAN2; goto num_operation;
+        case element::instruction_binary::op::div:   op = LMNT_OP_DIVSS; goto num_operation;
+        case element::instruction_binary::op::max:   op = LMNT_OP_MAXSS; goto num_operation;
+        case element::instruction_binary::op::min:   op = LMNT_OP_MINSS; goto num_operation;
+        case element::instruction_binary::op::mul:   op = LMNT_OP_MULSS; goto num_operation;
+        case element::instruction_binary::op::pow:   op = LMNT_OP_POWSS; goto num_operation;
+        case element::instruction_binary::op::rem:   op = LMNT_OP_MODSS; goto num_operation;
+        case element::instruction_binary::op::sub:   op = LMNT_OP_SUBSS; goto num_operation;
+    num_operation:
+            output.emplace_back(lmnt_instruction{op, arg1_vr.stack_index, arg2_vr.stack_index, output_idx});
+            return ELEMENT_OK;
+
+        case element::instruction_binary::op::log:
+            // TODO: check if we've got a constant base we can work with
+            output.emplace_back(lmnt_instruction{LMNT_OP_LOG, arg1_vr.stack_index, arg2_vr.stack_index, output_idx});
+            return ELEMENT_OK;
+
+        default:
+            break;
+    }
+
+    const uint32_t start_idx = static_cast<uint32_t>(output.size()); // index of the next op
+
+    switch(eb.operation())
+    {
+        //boolean
+        case element::instruction_binary::op::and_:
+            // (arg1 > 0.0 && arg2 > 0.0)
+            output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, arg1_vr.stack_index, 0, 0});                            // + 0
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCLE, 0, U16_LO(start_idx + 6), U16_HI(start_idx + 6)}); // + 1
+            output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, arg2_vr.stack_index, 0, 0});                            // + 2
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCLE, 0, U16_LO(start_idx + 6), U16_HI(start_idx + 6)}); // + 3
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 1, 0, output_idx});                                // + 4
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH,    0, U16_LO(start_idx + 7), U16_HI(start_idx + 7)}); // + 5
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 0, 0, output_idx});                                // + 6
+            return ELEMENT_OK;
+        case element::instruction_binary::op::or_:
+            // (arg1 > 0.0 || arg2 > 0.0)
+            output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, arg1_vr.stack_index, 0, 0});                            // + 0
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCGT, 0, U16_LO(start_idx + 6), U16_HI(start_idx + 6)}); // + 1
+            output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, arg2_vr.stack_index, 0, 0});                            // + 2
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCGT, 0, U16_LO(start_idx + 6), U16_HI(start_idx + 6)}); // + 3
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 0, 0, output_idx});                                // + 4
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH, 0, U16_LO(start_idx + 7), U16_HI(start_idx + 7)});    // + 5
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 1, 0, output_idx});                                // + 6
+            return ELEMENT_OK;
+
+        //comparison
+        case element::instruction_binary::op::eq:  op = LMNT_OP_BRANCHCEQ; goto cmp_operation;
+        case element::instruction_binary::op::neq: op = LMNT_OP_BRANCHCNE; goto cmp_operation;
+        case element::instruction_binary::op::lt:  op = LMNT_OP_BRANCHCLT; goto cmp_operation;
+        case element::instruction_binary::op::leq: op = LMNT_OP_BRANCHCLE; goto cmp_operation;
+        case element::instruction_binary::op::gt:  op = LMNT_OP_BRANCHCGT; goto cmp_operation;
+        case element::instruction_binary::op::geq: op = LMNT_OP_BRANCHCGE; goto cmp_operation;
+    cmp_operation:
+            output.emplace_back(lmnt_instruction{LMNT_OP_CMP, arg1_vr.stack_index, arg2_vr.stack_index, 0});        // + 0
+            output.emplace_back(lmnt_instruction{op, 0, U16_LO(start_idx + 4), U16_HI(start_idx + 4)});             // + 1
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 0, 0, output_idx});                             // + 2
+            output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH, 0, U16_LO(start_idx + 5), U16_HI(start_idx + 5)}); // + 3
+            output.emplace_back(lmnt_instruction{LMNT_OP_ASSIGNIIS, 1, 0, output_idx});                             // + 4
+            return ELEMENT_OK;
+
+        default:
+            assert(false);
+            return ELEMENT_ERROR_UNKNOWN;
+    }
+}
+
+
+//
+// If
+//
+
+static element_result create_virtual_if(
+    compiler_state& state,
+    const element::instruction_if& ei,
+    virtual_result& result)
+{
+    if (ei.dependents().size() != 3)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    // ensure the predicate is only 1 wide
+    virtual_result predicate_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ei.dependents()[0].get(), predicate_vr));
+    if (predicate_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    // ensure both results of the if are at least the same size
+    virtual_result true_vr, false_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ei.dependents()[1].get(), true_vr));
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ei.dependents()[2].get(), false_vr));
+    if (true_vr.count != false_vr.count)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    result.instruction = &ei;
+    result.count = true_vr.count;
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_if(
+    compiler_state& state,
+    const element::instruction_if& ei,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    virtual_result predicate_vr, true_vr, false_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ei.dependents()[0].get(), predicate_vr));
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ei.dependents()[1].get(), true_vr));
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ei.dependents()[2].get(), false_vr));
+
+    // compile the predicate
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, predicate_vr.instruction, output));
+    // make branch logic
+    output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, predicate_vr.stack_index, 0, 0});
+    const size_t predicate_branchcle_idx = output.size();
+    output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCLE, 0, 0, 0}); // target filled in at the end
+    // compile the true/false branches
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, true_vr.instruction, output));
+    copy_stack_values(true_vr.stack_index, output_idx, true_vr.count, output);
+    const size_t branch_past_idx = output.size();
+    output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH, 0, 0, 0}); // target filled in at the end
+    const size_t false_idx = output.size();
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, false_vr.instruction, output));
+    copy_stack_values(false_vr.stack_index, output_idx, true_vr.count, output);
+    const size_t past_idx = output.size();
+
+    // fill in targets for our branches
+    output[predicate_branchcle_idx].arg2 = U16_LO(false_idx);
+    output[predicate_branchcle_idx].arg3 = U16_HI(false_idx);
+    output[branch_past_idx].arg2 = U16_LO(past_idx);
+    output[branch_past_idx].arg3 = U16_HI(past_idx);
+
+    return ELEMENT_OK;
+}
+
+
+//
+// For
+//
+
+static element_result create_virtual_for(
+    compiler_state& state,
+    const element::instruction_for& ef,
+    virtual_result& result)
+{
+    if (ef.dependents().size() != 3)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    virtual_result initial_vr, condition_vr, body_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.dependents()[0].get(), initial_vr));
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.dependents()[1].get(), condition_vr));
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.dependents()[2].get(), body_vr));
+    if (condition_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+    if (initial_vr.count != body_vr.count)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    result.instruction = &ef;
+    result.count = initial_vr.count;
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_for(
+    compiler_state& state,
+    const element::instruction_for& ef,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    virtual_result initial_vr, condition_vr, body_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ef.dependents()[0].get(), initial_vr));
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ef.dependents()[1].get(), condition_vr));
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ef.dependents()[2].get(), body_vr));
+
+    // compile the initial state
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, initial_vr.instruction, output));
+    copy_stack_values(initial_vr.stack_index, output_idx, initial_vr.count, output);
+    // compile condition logic
+    const size_t condition_index = output.size();
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, condition_vr.instruction, output));
+    output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, condition_vr.stack_index, 0, 0});
+    const size_t condition_branchcle_idx = output.size();
+    output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCLE, 0, 0, 0}); // target filled in at the end
+    // compile the loop body
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, body_vr.instruction, output));
+    copy_stack_values(body_vr.stack_index, output_idx, body_vr.count, output);
+    const size_t branch_past_idx = output.size();
+    output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH, 0, U16_LO(condition_index), U16_HI(condition_index)}); // branch --> condition
+    const size_t past_idx = output.size();
+
+    // fill in targets for the exit branch
+    output[condition_branchcle_idx].arg2 = U16_LO(past_idx);
+    output[condition_branchcle_idx].arg3 = U16_HI(past_idx);
+
+    return ELEMENT_OK;
+}
+
+
+//
+// Indexer
+//
+
+static element_result create_virtual_indexer(
+    compiler_state& state,
+    const element::instruction_indexer& ei,
+    virtual_result& result)
+{
+    virtual_result for_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, ei.for_instruction.get(), for_vr));
+    if (ei.index >= for_vr.count)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    result.instruction = &ei;
+    result.count = 1;
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_indexer(
+    compiler_state& state,
+    const element::instruction_indexer& ei,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    virtual_result for_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(ei.for_instruction.get(), for_vr));
+
+    const uint16_t for_entry_idx = static_cast<uint16_t>(for_vr.stack_index + ei.index);
+    copy_stack_values(for_entry_idx, output_idx, 1, output);
+    return ELEMENT_OK;
+}
+
+
+//
+// Select
+//
+
+static element_result create_virtual_select(
+    compiler_state& state,
+    const element::instruction_select& es,
+    virtual_result& result)
+{
+    virtual_result selector_vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, es.selector.get(), selector_vr));
+    if (selector_vr.count != 1)
+        return ELEMENT_ERROR_UNKNOWN;
+
+    if (es.options.empty())
+        return ELEMENT_ERROR_UNKNOWN;
+
+    ELEMENT_OK_OR_RETURN(state.add_constant(0));
+    ELEMENT_OK_OR_RETURN(state.add_constant(1));
+    ELEMENT_OK_OR_RETURN(state.add_constant(element_value(es.options.size() - 1)));
+
+    uint16_t max_count = 0;
+    for (const auto& o : es.options)
+    {
+        virtual_result option_vr;
+        ELEMENT_OK_OR_RETURN(create_virtual_result(state, o.get(), option_vr));
+        max_count = (std::max)(max_count, static_cast<uint16_t>(option_vr.count));
+    }
+
+    result.instruction = &es;
+    result.count = max_count;
+
+    return ELEMENT_OK;
+}
+
+static element_result compile_select(
+    compiler_state& state,
+    const element::instruction_select& es,
+    const uint16_t output_idx,
+    std::vector<lmnt_instruction>& output)
+{
+    const size_t opts_size = es.options.size();
+    uint16_t zero_idx, one_idx, last_valid_idx;
+    ELEMENT_OK_OR_RETURN(state.find_constant(0, zero_idx));
+    ELEMENT_OK_OR_RETURN(state.find_constant(1, one_idx));
+    ELEMENT_OK_OR_RETURN(state.find_constant(element_value(opts_size - 1), last_valid_idx));
+
+    virtual_result selector_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(es.selector.get(), selector_vr));
+    ELEMENT_OK_OR_RETURN(compile_instruction(state, es.selector.get(), output));
+    // clamp in range and ensure it's an integer
+    output.emplace_back(lmnt_instruction{LMNT_OP_MAXSS,  selector_vr.stack_index, zero_idx, selector_vr.stack_index});
+    output.emplace_back(lmnt_instruction{LMNT_OP_MINSS,  selector_vr.stack_index, last_valid_idx, selector_vr.stack_index});
+    output.emplace_back(lmnt_instruction{LMNT_OP_TRUNCS, selector_vr.stack_index, 0, selector_vr.stack_index});
+
+    const size_t branches_start_idx = output.size();
+    for (size_t i = 0; i < opts_size; ++i)
+    {
+        output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, selector_vr.stack_index, 0, 0});
+        output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCEQ, 0, 0, 0}); // target filled in later
+        output.emplace_back(lmnt_instruction{LMNT_OP_SUBSS, selector_vr.stack_index, one_idx, selector_vr.stack_index});
+    }
+
+    virtual_result option0_vr;
+    ELEMENT_OK_OR_RETURN(state.find_virtual_result(es.options[0].get(), option0_vr));
+    const bool stacked = (option0_vr.stack_index == output_idx);
+
+    std::vector<size_t> option_branch_indexes(opts_size);
+
+    for (size_t i = 0; i < opts_size; ++i)
+    {
+        virtual_result option_vr;
+        ELEMENT_OK_OR_RETURN(state.find_virtual_result(es.options[i].get(), option_vr));
+
+        const size_t option_idx = output.size();
+        // fill in the target index for this branch option
+        output[branches_start_idx + i*3 + 1].arg2 = U16_LO(option_idx);
+        output[branches_start_idx + i*3 + 1].arg3 = U16_HI(option_idx);
+        ELEMENT_OK_OR_RETURN(compile_instruction(state, es.options[i].get(), output));
+        copy_stack_values(option_vr.stack_index, output_idx, option_vr.count, output);
+        option_branch_indexes[i] = output.size();
+        output.emplace_back(lmnt_instruction{LMNT_OP_BRANCH, 0, 0, 0}); // target filled in later
+    }
+
+    const size_t past_idx = output.size();
+    for (size_t i = 0; i < opts_size; ++i)
+    {
+        output[option_branch_indexes[i]].arg2 = U16_LO(past_idx);
+        output[option_branch_indexes[i]].arg3 = U16_HI(past_idx);
+    }
+
+    return ELEMENT_OK;
+}
+
+
+
+static element_result create_virtual_result(
+    compiler_state& state,
+    const element::instruction* expr,
+    virtual_result& result)
+{
+    // CSE
+    if (auto it = state.results.find(expr); it != state.results.end())
+    {
+        result = state.virtual_results[it->second];
+        return ELEMENT_OK;
+    }
+
+    element_result oresult = ELEMENT_ERROR_NO_IMPL;
+
+    if (const auto* ec = expr->as<element::instruction_constant>())
+        oresult = create_virtual_constant(state, *ec, result);
+
+    if (const auto* ei = expr->as<element::instruction_input>())
+        oresult = create_virtual_input(state, *ei, result);
+
+    if (const auto* es = expr->as<element::instruction_serialised_structure>())
+        oresult = create_virtual_serialised_structure(state, *es, result);
+
+    if (const auto* en = expr->as<element::instruction_nullary>())
+        oresult = create_virtual_nullary(state, *en, result);
+
+    if (const auto* eu = expr->as<element::instruction_unary>())
+        oresult = create_virtual_unary(state, *eu, result);
+
+    if (const auto* eb = expr->as<element::instruction_binary>())
+        oresult = create_virtual_binary(state, *eb, result);
+
+    if (const auto* ei = expr->as<element::instruction_if>())
+        oresult = create_virtual_if(state, *ei, result);
+
+    if (const auto* ef = expr->as<element::instruction_for>())
+        oresult = create_virtual_for(state, *ef, result);
+
+    if (const auto* ei = expr->as<element::instruction_indexer>())
+        oresult = create_virtual_indexer(state, *ei, result);
+
+    if (const auto* sel = expr->as<element::instruction_select>())
+        oresult = create_virtual_select(state, *sel, result);
+
+    if (oresult == ELEMENT_OK)
+    {
+        state.results.emplace(expr, state.virtual_results.size());
+        state.virtual_results.emplace_back(result);
+    }
+
+    return oresult;
+}
+
+static element_result compile_instruction(
+    compiler_state& state,
+    const element::instruction* expr,
+    std::vector<lmnt_instruction>& output)
+{
+    auto results_it = state.results.find(expr);
+    if (results_it == state.results.end())
+        return ELEMENT_ERROR_UNKNOWN;
+
+    const virtual_result& vr = state.virtual_results[results_it->second];
+
+    if (const auto* ec = expr->as<element::instruction_constant>())
+        return compile_constant(state, *ec, vr.stack_index, output);
+
+    if (const auto* ei = expr->as<element::instruction_input>())
+        return compile_input(state, *ei, vr.stack_index, output);
+
+    if (const auto* es = expr->as<element::instruction_serialised_structure>())
+        return compile_serialised_structure(state, *es, vr.stack_index, output);
+
+    if (const auto* en = expr->as<element::instruction_nullary>())
+        return compile_nullary(state, *en, vr.stack_index, output);
+
+    if (const auto* eu = expr->as<element::instruction_unary>())
+        return compile_unary(state, *eu, vr.stack_index, output);
+
+    if (const auto* eb = expr->as<element::instruction_binary>())
+        return compile_binary(state, *eb, vr.stack_index, output);
+
+    if (const auto* ei = expr->as<element::instruction_if>())
+        return compile_if(state, *ei, vr.stack_index, output);
+
+    if (const auto* ef = expr->as<element::instruction_for>())
+        return compile_for(state, *ef, vr.stack_index, output);
+
+    if (const auto* ei = expr->as<element::instruction_indexer>())
+        return compile_indexer(state, *ei, vr.stack_index, output);
+
+    if (const auto* sel = expr->as<element::instruction_select>())
+        return compile_select(state, *sel, vr.stack_index, output);
+
+    return ELEMENT_ERROR_NO_IMPL;
+}
+
+
+element_result element_lmnt_find_constants(
+    const element_lmnt_compiler_ctx& ctx,
+    const element::instruction_const_shared_ptr& expr,
+    std::unordered_map<element_value, size_t>& candidates)
+{
+    if (const auto* ec = expr->as<element::instruction_constant>())
+    {
+        const element_value value = ec->value();
+        auto it = candidates.find(value);
+        if (it != candidates.end())
+            ++it->second;
+        else
+            candidates.emplace(value, 1);
+    }
+    for (const auto& dep : expr->dependents())
+    {
+        ELEMENT_OK_OR_RETURN(element_lmnt_find_constants(ctx, dep, candidates));
+    }
+    return ELEMENT_OK;
+}
+
+element_result element_lmnt_compile_function(
+    const element_lmnt_compiler_ctx& ctx,
+    const element::instruction_const_shared_ptr instruction,
+    std::vector<element_value> constants,
+    const size_t inputs_count,
+    std::vector<lmnt_instruction>& output)
+{
+    compiler_state state { ctx, std::move(constants), static_cast<uint16_t>(inputs_count) };
+    // TODO: check for single constant fast path
+    virtual_result vr;
+    ELEMENT_OK_OR_RETURN(create_virtual_result(state, instruction.get(), vr));
+    return compile_instruction(state, instruction.get(), output);
+}

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -7,7 +7,9 @@
 struct element_lmnt_compiler_optimisers
 {
     // bool cse; // required
-    bool stack_reuse;
+    size_t constant_reuse_threshold = 2;
+    bool minimise_moves = true;
+    bool stack_reuse = true;
 };
 
 struct element_lmnt_compiler_ctx

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+#include "instruction_tree/instructions.hpp"
+#include "lmnt/archive.h"
+
+struct element_lmnt_compiler_optimisers
+{
+    // bool cse; // required
+    bool stack_reuse;
+};
+
+struct element_lmnt_compiler_ctx
+{
+    element_lmnt_compiler_optimisers optimise;
+};
+
+element_result element_lmnt_find_constants(
+    const element_lmnt_compiler_ctx& ctx,
+    const element::instruction_const_shared_ptr& instruction,
+    std::unordered_map<element_value, size_t>& candidates);
+
+element_result element_lmnt_compile_function(
+    const element_lmnt_compiler_ctx& ctx,
+    const element::instruction_const_shared_ptr instruction,
+    const std::vector<element_value>& constants,
+    const size_t inputs_count,
+    std::vector<lmnt_instruction>& output);

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -25,6 +25,6 @@ element_result element_lmnt_find_constants(
 element_result element_lmnt_compile_function(
     const element_lmnt_compiler_ctx& ctx,
     const element::instruction_const_shared_ptr instruction,
-    const std::vector<element_value>& constants,
+    std::vector<element_value>& constants,
     const size_t inputs_count,
     std::vector<lmnt_instruction>& output);

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -7,7 +7,7 @@
 struct element_lmnt_compiler_optimisers
 {
     // bool cse; // required
-    size_t constant_reuse_threshold = 2;
+    size_t constant_reuse_threshold = 1;
     bool minimise_moves = true;
     bool stack_reuse = true;
 };

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -20,9 +20,11 @@ struct element_lmnt_compiler_ctx
 struct element_lmnt_compiled_function
 {
     std::vector<lmnt_instruction> instructions;
-    size_t required_stack_count;
+    size_t local_stack_count;
     size_t inputs_count;
     size_t outputs_count;
+
+    size_t total_stack_count() const { return inputs_count + outputs_count + local_stack_count; }
 };
 
 element_result element_lmnt_find_constants(

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -17,6 +17,14 @@ struct element_lmnt_compiler_ctx
     element_lmnt_compiler_optimisers optimise;
 };
 
+struct element_lmnt_compiled_function
+{
+    std::vector<lmnt_instruction> instructions;
+    size_t required_stack_count;
+    size_t inputs_count;
+    size_t outputs_count;
+};
+
 element_result element_lmnt_find_constants(
     const element_lmnt_compiler_ctx& ctx,
     const element::instruction_const_shared_ptr& instruction,
@@ -27,4 +35,4 @@ element_result element_lmnt_compile_function(
     const element::instruction_const_shared_ptr instruction,
     std::vector<element_value>& constants,
     const size_t inputs_count,
-    std::vector<lmnt_instruction>& output);
+    element_lmnt_compiled_function& output);

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -1,10 +1,28 @@
 #include "lmnt/compiler_state.hpp"
 
+
+element_result compiler_state::get_allocation_type(const element::instruction* in, allocation_type& type) const
+{
+    auto it = _allocations.find(in);
+    if (it != _allocations.end())
+    {
+        type = it->second->type();
+        return ELEMENT_OK;
+    }
+    return ELEMENT_ERROR_NOT_FOUND;
+}
+
+bool compiler_state::is_allocation_type(const element::instruction* in, allocation_type type) const
+{
+    auto it = _allocations.find(in);
+    return (it != _allocations.end() && it->second->type() == type);
+}
+
 element_result compiler_state::set_allocation(const element::instruction* in, uint16_t count)
 {
     size_t inst_idx = results.at(in);
     auto result = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, inst_idx, inst_idx}));
-    return (result.second) ? ELEMENT_OK : ELEMENT_ERROR_UNKNOWN;
+    return (result.second) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
 }
 
 element_result compiler_state::set_allocation_if_not_pinned(const element::instruction* in, uint16_t count)
@@ -14,7 +32,7 @@ element_result compiler_state::set_allocation_if_not_pinned(const element::instr
     auto it = _allocations.find(in);
     if (it != _allocations.end() && it->second->count == count && it->second->pinned)
         return ELEMENT_OK;
-    return ELEMENT_ERROR_UNKNOWN;
+    return ELEMENT_ERROR_NOT_FOUND;
 }
 
 element_result compiler_state::clear_allocation(const element::instruction* in)

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -79,6 +79,9 @@ element_result compiler_state::stack_allocator::set_parent(const element::instru
     if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
     auto parent_it = _allocations.find(parent);
     if (parent_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    // cannot displace a pinned allocation
+    if (child_it->second->pinned())
+        return ELEMENT_ERROR_INVALID_OPERATION;
     // ensure we actually fit in our new parent allocation
     if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
     child_it->second->parent = parent_it->second->shared_from_this();

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -79,8 +79,6 @@ element_result compiler_state::stack_allocator::set_parent(const element::instru
     if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
     auto parent_it = _allocations.find(parent);
     if (parent_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
-    // if allocation is pinned we cannot move it
-    if (child_it->second->pinned()) return ELEMENT_ERROR_INVALID_OPERATION;
     // ensure we actually fit in our new parent allocation
     if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
     child_it->second->parent = parent_it->second->shared_from_this();

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -11,112 +11,121 @@ compiler_state::compiler_state(const element_lmnt_compiler_ctx& c, const element
     allocator = std::make_unique<naive_allocator>();
 }
 
-stack_allocation* compiler_state::stack_allocator::get(const element::instruction* in)
+stack_allocation* compiler_state::stack_allocator::get(const element::instruction* in, size_t alloc_index)
 {
     auto it = _allocations.find(in);
-    return (it != _allocations.end()) ? it->second : nullptr;
+    return (it != _allocations.end() && alloc_index < it->second.size()) ? it->second[alloc_index] : nullptr;
 }
 
-const stack_allocation* compiler_state::stack_allocator::get(const element::instruction* in) const
+const stack_allocation* compiler_state::stack_allocator::get(const element::instruction* in, size_t alloc_index) const
 {
     auto it = _allocations.find(in);
-    return (it != _allocations.end()) ? it->second : nullptr;
+    return (it != _allocations.end() && alloc_index < it->second.size()) ? it->second[alloc_index] : nullptr;
 }
 
-element_result compiler_state::stack_allocator::get_type(const element::instruction* in, allocation_type& type) const
+size_t compiler_state::stack_allocator::count(const element::instruction* in) const
 {
     auto it = _allocations.find(in);
-    if (it != _allocations.end())
+    return (it != _allocations.end()) ? it->second.size() : 0;
+}
+
+element_result compiler_state::stack_allocator::get_type(const element::instruction* in, size_t alloc_index, allocation_type& type) const
+{
+    auto it = _allocations.find(in);
+    if (it != _allocations.end() && alloc_index < it->second.size())
     {
-        type = it->second->type();
+        type = it->second[alloc_index]->type();
         return ELEMENT_OK;
     }
     return ELEMENT_ERROR_NOT_FOUND;
 }
 
-bool compiler_state::stack_allocator::is_type(const element::instruction* in, allocation_type type) const
+bool compiler_state::stack_allocator::is_type(const element::instruction* in, size_t alloc_index, allocation_type type) const
 {
     auto it = _allocations.find(in);
-    return (it != _allocations.end() && it->second->type() == type);
+    return (it != _allocations.end() && alloc_index < it->second.size() && it->second[alloc_index]->type() == type);
 }
 
-element_result compiler_state::stack_allocator::add(const element::instruction* in, size_t inst_idx, uint16_t count, stack_allocation** vr)
+element_result compiler_state::stack_allocator::add(const element::instruction* in, uint16_t count, stack_allocation** vr)
 {
-    auto allocation = std::make_shared<stack_allocation>(in, count, inst_idx, inst_idx);
-    auto result = _allocations.try_emplace(in, allocation.get());
-    if (vr) *vr = result.first->second;
-    if (result.second)
-    {
-        _alloc_storage.emplace_back(std::move(allocation));
-        return ELEMENT_OK;
-    }
-    else
-    {
-        return ELEMENT_ERROR_UNKNOWN;
-    }
-}
-
-element_result compiler_state::stack_allocator::set_count(const element::instruction* in, uint16_t count)
-{
-    auto it = _allocations.find(in);
-    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
-
-    it->second->count = count;
+    auto allocation = std::make_shared<stack_allocation>(in, count, 0, 0);
+    _allocations[in].emplace_back(allocation.get());
+    _alloc_storage.emplace_back(std::move(allocation));
+    if (vr) *vr = allocation.get();
     return ELEMENT_OK;
 }
 
-element_result compiler_state::stack_allocator::erase(const element::instruction* in)
+element_result compiler_state::stack_allocator::set_count(const element::instruction* in, size_t alloc_index, uint16_t count)
+{
+    auto it = _allocations.find(in);
+    if (it == _allocations.end() || alloc_index >= it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
+
+    it->second[alloc_index]->count = count;
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::stack_allocator::clear(const element::instruction* in)
 {
     size_t count = _allocations.erase(in);
     _alloc_storage.erase(
-        std::find_if(_alloc_storage.begin(), _alloc_storage.end(), [=](const auto& sa) { return sa->instruction == in; }));
+        std::remove_if(_alloc_storage.begin(), _alloc_storage.end(), [=](const auto& sa) { return sa->instruction == in; }));
     return (count) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
 }
 
-element_result compiler_state::stack_allocator::set_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
+element_result compiler_state::stack_allocator::set_parent(const element::instruction* child, size_t child_alloc_index, const element::instruction* parent, size_t parent_alloc_index, uint16_t rel_index)
 {
     auto child_it = _allocations.find(child);
-    if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    if (child_it == _allocations.end() || child_alloc_index >= child_it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
     auto parent_it = _allocations.find(parent);
-    if (parent_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    if (parent_it == _allocations.end() || parent_alloc_index >= parent_it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
     // cannot displace a pinned allocation
-    if (child_it->second->pinned())
+    if (child_it->second[child_alloc_index]->pinned())
         return ELEMENT_ERROR_INVALID_OPERATION;
     // ensure we actually fit in our new parent allocation
-    if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
-    child_it->second->parent = parent_it->second->shared_from_this();
-    child_it->second->rel_index = rel_index;
+    if (child_it->second[child_alloc_index]->count > parent_it->second[parent_alloc_index]->count) return ELEMENT_ERROR_INVALID_OPERATION;
+    child_it->second[child_alloc_index]->parent = parent_it->second[parent_alloc_index]->shared_from_this();
+    child_it->second[child_alloc_index]->rel_index = rel_index;
     return ELEMENT_OK;
 }
 
-element_result compiler_state::stack_allocator::use(const element::instruction* current_in, const element::instruction* alloc_in)
+element_result compiler_state::stack_allocator::use(const element::instruction* current_in, size_t child_index, const element::instruction* alloc_in, size_t alloc_index)
 {
     auto a_it = _allocations.find(alloc_in);
-    if (a_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    if (a_it == _allocations.end() || alloc_index >= a_it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
     auto c_it = _allocations.find(current_in);
-    if (c_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    if (c_it == _allocations.end() || child_index >= c_it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
 
-    a_it->second->last_used_instruction = c_it->second->set_instruction;
+    a_it->second[alloc_index]->last_used_instruction = c_it->second[child_index]->set_instruction;
     return ELEMENT_OK;
 }
 
-element_result compiler_state::stack_allocator::set_pinned(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count)
+element_result compiler_state::stack_allocator::set_pinned(const element::instruction* in, size_t alloc_index, allocation_type type, uint16_t index, uint16_t count)
+{
+    auto it = _allocations.find(in);
+    if (it == _allocations.end() || alloc_index >= it->second.size()) return ELEMENT_ERROR_NOT_FOUND;
+
+    it->second[alloc_index]->parent = nullptr;
+    it->second[alloc_index]->rel_type = type;
+    it->second[alloc_index]->rel_index = index;
+    it->second[alloc_index]->count = count;
+    it->second[alloc_index]->last_used_instruction = it->second[alloc_index]->set_instruction;
+    it->second[alloc_index]->rel_pinned = true;
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::stack_allocator::set_stage(const element::instruction* in, compilation_stage stage)
 {
     auto it = _allocations.find(in);
     if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
 
-    it->second->parent = nullptr;
-    it->second->rel_type = type;
-    it->second->rel_index = index;
-    it->second->count = count;
-    it->second->last_used_instruction = it->second->set_instruction;
-    it->second->rel_pinned = true;
+    for (auto* alloc : it->second)
+        alloc->stage = stage;
     return ELEMENT_OK;
 }
 
-element_result compiler_state::calculate_stack_index(const element::instruction* in, uint16_t& index) const
+element_result compiler_state::calculate_stack_index(const element::instruction* in, uint16_t& index, size_t alloc_index) const
 {
-    stack_allocation* alloc = allocator->get(in);
+    stack_allocation* alloc = allocator->get(in, alloc_index);
     if (!alloc) return ELEMENT_ERROR_NOT_FOUND;
     index = calculate_stack_index(alloc->type(), alloc->index());
     return ELEMENT_OK;
@@ -170,9 +179,11 @@ element_result compiler_state::find_constant(element_value value, uint16_t& inde
 uint16_t compiler_state::stack_allocator::get_max_stack_usage() const
 {
     uint16_t cur = 0;
-    for (const auto& alloc : _allocations) {
-        if (alloc.second->type() == allocation_type::local) {
-            cur = uint16_t((std::max)(cur, uint16_t(alloc.second->index() + alloc.second->count)));
+    for (const auto& alloc_vec : _allocations) {
+        for (const auto& alloc : alloc_vec.second) {
+            if (alloc->type() == allocation_type::local) {
+                cur = uint16_t((std::max)(cur, uint16_t(alloc->index() + alloc->count)));
+            }
         }
     }
     return cur;

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -1,64 +1,80 @@
 #include "lmnt/compiler_state.hpp"
 
-element_result compiler_stack_info::set_allocation(const element::instruction* in, uint16_t count)
+element_result compiler_state::set_allocation(const element::instruction* in, uint16_t count)
 {
-    size_t inst_idx = _state.results.at(in);
+    size_t inst_idx = results.at(in);
     auto result = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, inst_idx, inst_idx}));
     return (result.second) ? ELEMENT_OK : ELEMENT_ERROR_UNKNOWN;
 }
 
-element_result compiler_stack_info::clear_allocation(const element::instruction* in)
+element_result compiler_state::set_allocation_if_not_pinned(const element::instruction* in, uint16_t count)
+{
+    if (set_allocation(in, count) == ELEMENT_OK)
+        return ELEMENT_OK;
+    auto it = _allocations.find(in);
+    if (it != _allocations.end() && it->second->count == count && it->second->pinned)
+        return ELEMENT_OK;
+    return ELEMENT_ERROR_UNKNOWN;
+}
+
+element_result compiler_state::clear_allocation(const element::instruction* in)
 {
     return _allocations.erase(in) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
 }
 
-element_result compiler_stack_info::set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
+element_result compiler_state::set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
 {
     auto child_it = _allocations.find(child);
     if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
     auto parent_it = _allocations.find(parent);
     if (parent_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    // TODO: ensure child isn't pinned
     // ensure we actually fit in our new parent allocation
     if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
     child_it->second->parent = parent_it->second;
-    child_it->second->stack_rel_index = rel_index;
+    child_it->second->rel_index = rel_index;
     return ELEMENT_OK;
 }
 
-element_result compiler_stack_info::use_allocation(const element::instruction* current_in, const element::instruction* alloc_in)
+element_result compiler_state::use_allocation(const element::instruction* current_in, const element::instruction* alloc_in)
 {
     auto it = _allocations.find(alloc_in);
     if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
 
-    it->second->last_used_instruction = _state.results.at(current_in);
+    it->second->last_used_instruction = results.at(current_in);
     return ELEMENT_OK;
 }
 
-element_result compiler_stack_info::use_pinned_allocation(const element::instruction* in, uint16_t index, uint16_t count)
+element_result compiler_state::use_pinned_allocation(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count)
 {
-    const size_t inst_idx = _state.results.at(in);
-    auto it = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, 0, inst_idx, nullptr, index, true, index}));
-    if (!it.first->second->pinned || it.first->second->pinned_index != index || it.first->second->count != count)
+    const size_t inst_idx = results.at(in);
+    auto it = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, 0, inst_idx, nullptr, type, index, true}));
+    if (!it.first->second->pinned || it.first->second->cur_type != type || it.first->second->rel_index != index || it.first->second->count != count)
         return ELEMENT_ERROR_UNKNOWN;
     it.first->second->last_used_instruction = inst_idx;
     return ELEMENT_OK;
 }
 
-element_result compiler_stack_info::get_stack_index(const element::instruction* in, uint16_t& index)
+element_result compiler_state::get_stack_index(const element::instruction* in, uint16_t& index)
 {
     auto it = _allocations.find(in);
     if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
-    index = it->second->stack_index();
+    index = get_stack_index(it->second->type(), it->second->index());
     return ELEMENT_OK;
 }
 
-element_result compiler_stack_info::set_stack_index(const element::instruction* in, uint16_t index)
+uint16_t compiler_state::get_stack_index(const allocation_type type, uint16_t index)
 {
-    auto it = _allocations.find(in);
-    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
-    it->second->parent = nullptr;
-    it->second->stack_rel_index = index;
-    return ELEMENT_OK;
+    if (type == allocation_type::constant)
+        return index;
+    index += static_cast<uint16_t>(constants.size());
+    if (type == allocation_type::input)
+        return index;
+    index += inputs_count;
+    if (type == allocation_type::output)
+        return index;
+    index += virtual_results[results[return_instruction]].count;
+    return index;
 }
 
 element_result compiler_state::add_constant(element_value value, uint16_t* index)
@@ -77,26 +93,20 @@ element_result compiler_state::add_constant(element_value value, uint16_t* index
 
 element_result compiler_state::find_constant(element_value value, uint16_t& index)
 {
-    if (auto it = std::find(constants.begin(), constants.end(), value); it != constants.end())
-    {
+    if (auto it = std::find(constants.begin(), constants.end(), value); it != constants.end()) {
         index = static_cast<uint16_t>(std::distance(constants.begin(), it));
         return ELEMENT_OK;
-    }
-    else
-    {
+    } else {
         return ELEMENT_ERROR_NOT_FOUND;
     }
 }
 
 element_result compiler_state::find_virtual_result(const element::instruction* in, virtual_result& vr)
 {
-    if (auto it = results.find(in); it != results.end() && it->second < virtual_results.size())
-    {
+    if (auto it = results.find(in); it != results.end() && it->second < virtual_results.size()) {
         vr = virtual_results[it->second];
         return ELEMENT_OK;
-    }
-    else
-    {
+    } else {
         return ELEMENT_ERROR_NOT_FOUND;
     }
 }

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -1,0 +1,102 @@
+#include "lmnt/compiler_state.hpp"
+
+element_result compiler_stack_info::set_allocation(const element::instruction* in, uint16_t count)
+{
+    size_t inst_idx = _state.results.at(in);
+    auto result = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, inst_idx, inst_idx}));
+    return (result.second) ? ELEMENT_OK : ELEMENT_ERROR_UNKNOWN;
+}
+
+element_result compiler_stack_info::clear_allocation(const element::instruction* in)
+{
+    return _allocations.erase(in) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
+}
+
+element_result compiler_stack_info::set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
+{
+    auto child_it = _allocations.find(child);
+    if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    auto parent_it = _allocations.find(parent);
+    if (parent_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    // ensure we actually fit in our new parent allocation
+    if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
+    child_it->second->parent = parent_it->second;
+    child_it->second->stack_rel_index = rel_index;
+    return ELEMENT_OK;
+}
+
+element_result compiler_stack_info::use_allocation(const element::instruction* current_in, const element::instruction* alloc_in)
+{
+    auto it = _allocations.find(alloc_in);
+    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+
+    it->second->last_used_instruction = _state.results.at(current_in);
+    return ELEMENT_OK;
+}
+
+element_result compiler_stack_info::use_pinned_allocation(const element::instruction* in, uint16_t index, uint16_t count)
+{
+    const size_t inst_idx = _state.results.at(in);
+    auto it = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, 0, inst_idx, nullptr, index, true, index}));
+    if (!it.first->second->pinned || it.first->second->pinned_index != index || it.first->second->count != count)
+        return ELEMENT_ERROR_UNKNOWN;
+    it.first->second->last_used_instruction = inst_idx;
+    return ELEMENT_OK;
+}
+
+element_result compiler_stack_info::get_stack_index(const element::instruction* in, uint16_t& index)
+{
+    auto it = _allocations.find(in);
+    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    index = it->second->stack_index();
+    return ELEMENT_OK;
+}
+
+element_result compiler_stack_info::set_stack_index(const element::instruction* in, uint16_t index)
+{
+    auto it = _allocations.find(in);
+    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    it->second->parent = nullptr;
+    it->second->stack_rel_index = index;
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::add_constant(element_value value, uint16_t* index)
+{
+    if (constants.size() >= UINT16_MAX)
+        return ELEMENT_ERROR_UNKNOWN;
+    auto it = std::find(constants.begin(), constants.end(), value);
+    // if it didn't exist before, add it
+    if (it == constants.end())
+        constants.emplace_back(value);
+    // if we're returning the index, use the iterator's position (which is now valid either way)
+    if (index)
+        *index = static_cast<uint16_t>(std::distance(constants.begin(), it));
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::find_constant(element_value value, uint16_t& index)
+{
+    if (auto it = std::find(constants.begin(), constants.end(), value); it != constants.end())
+    {
+        index = static_cast<uint16_t>(std::distance(constants.begin(), it));
+        return ELEMENT_OK;
+    }
+    else
+    {
+        return ELEMENT_ERROR_NOT_FOUND;
+    }
+}
+
+element_result compiler_state::find_virtual_result(const element::instruction* in, virtual_result& vr)
+{
+    if (auto it = results.find(in); it != results.end() && it->second < virtual_results.size())
+    {
+        vr = virtual_results[it->second];
+        return ELEMENT_OK;
+    }
+    else
+    {
+        return ELEMENT_ERROR_NOT_FOUND;
+    }
+}

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -1,7 +1,23 @@
 #include "lmnt/compiler_state.hpp"
+#include "lmnt/naive_allocator.hpp"
 
+compiler_state::compiler_state(const element_lmnt_compiler_ctx& c, const element::instruction* in, std::vector<element_value>& v, uint16_t icount)
+    : ctx(c)
+    , return_instruction(in)
+    , constants(v)
+    , inputs_count(icount)
+{
+    // TODO: better allocators
+    allocator = std::make_unique<naive_allocator>();
+}
 
-element_result compiler_state::get_allocation_type(const element::instruction* in, allocation_type& type) const
+stack_allocation* compiler_state::stack_allocator::get(const element::instruction* in) const
+{
+    auto it = _allocations.find(in);
+    return (it != _allocations.end()) ? it->second : nullptr;
+}
+
+element_result compiler_state::stack_allocator::get_type(const element::instruction* in, allocation_type& type) const
 {
     auto it = _allocations.find(in);
     if (it != _allocations.end())
@@ -12,35 +28,46 @@ element_result compiler_state::get_allocation_type(const element::instruction* i
     return ELEMENT_ERROR_NOT_FOUND;
 }
 
-bool compiler_state::is_allocation_type(const element::instruction* in, allocation_type type) const
+bool compiler_state::stack_allocator::is_type(const element::instruction* in, allocation_type type) const
 {
     auto it = _allocations.find(in);
     return (it != _allocations.end() && it->second->type() == type);
 }
 
-element_result compiler_state::set_allocation(const element::instruction* in, uint16_t count)
+element_result compiler_state::stack_allocator::add(const element::instruction* in, size_t inst_idx, uint16_t count, stack_allocation** vr)
 {
-    size_t inst_idx = inst_indices.at(in);
-    auto result = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, inst_idx, inst_idx}));
-    return (result.second) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
+    auto allocation = std::make_shared<stack_allocation>(in, count, inst_idx, inst_idx);
+    auto result = _allocations.try_emplace(in, allocation.get());
+    if (vr) *vr = result.first->second;
+    if (result.second)
+    {
+        _alloc_storage.emplace_back(std::move(allocation));
+        return ELEMENT_OK;
+    }
+    else
+    {
+        return ELEMENT_ERROR_UNKNOWN;
+    }
 }
 
-element_result compiler_state::set_allocation_if_not_pinned(const element::instruction* in, uint16_t count)
+element_result compiler_state::stack_allocator::set_count(const element::instruction* in, uint16_t count)
 {
-    if (set_allocation(in, count) == ELEMENT_OK)
-        return ELEMENT_OK;
     auto it = _allocations.find(in);
-    if (it != _allocations.end() && it->second->count == count && it->second->pinned)
-        return ELEMENT_OK;
-    return ELEMENT_ERROR_NOT_FOUND;
+    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+
+    it->second->count = count;
+    return ELEMENT_OK;
 }
 
-element_result compiler_state::clear_allocation(const element::instruction* in)
+element_result compiler_state::stack_allocator::erase(const element::instruction* in)
 {
-    return _allocations.erase(in) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
+    size_t count = _allocations.erase(in);
+    _alloc_storage.erase(
+        std::find_if(_alloc_storage.begin(), _alloc_storage.end(), [=](const auto& sa) { return sa->instruction == in; }));
+    return (count) ? ELEMENT_OK : ELEMENT_ERROR_NOT_FOUND;
 }
 
-element_result compiler_state::set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
+element_result compiler_state::stack_allocator::set_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index)
 {
     auto child_it = _allocations.find(child);
     if (child_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
@@ -49,35 +76,41 @@ element_result compiler_state::set_allocation_parent(const element::instruction*
     // TODO: ensure child isn't pinned
     // ensure we actually fit in our new parent allocation
     if (child_it->second->count > parent_it->second->count) return ELEMENT_ERROR_INVALID_OPERATION;
-    child_it->second->parent = parent_it->second;
+    child_it->second->parent = parent_it->second->shared_from_this();
     child_it->second->rel_index = rel_index;
     return ELEMENT_OK;
 }
 
-element_result compiler_state::use_allocation(const element::instruction* current_in, const element::instruction* alloc_in)
+element_result compiler_state::stack_allocator::use(const element::instruction* current_in, const element::instruction* alloc_in)
 {
-    auto it = _allocations.find(alloc_in);
-    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    auto a_it = _allocations.find(alloc_in);
+    if (a_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+    auto c_it = _allocations.find(current_in);
+    if (c_it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
 
-    it->second->last_used_instruction = inst_indices.at(current_in);
+    a_it->second->last_used_instruction = c_it->second->set_instruction;
     return ELEMENT_OK;
 }
 
-element_result compiler_state::use_pinned_allocation(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count)
+element_result compiler_state::stack_allocator::set_pinned(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count)
 {
-    const size_t inst_idx = inst_indices.at(in);
-    auto it = _allocations.try_emplace(in, std::make_shared<stack_allocation>(stack_allocation{in, count, 0, inst_idx, nullptr, type, index, true}));
-    if (!it.first->second->pinned || it.first->second->cur_type != type || it.first->second->rel_index != index || it.first->second->count != count)
-        return ELEMENT_ERROR_UNKNOWN;
-    it.first->second->last_used_instruction = inst_idx;
+    auto it = _allocations.find(in);
+    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
+
+    it->second->parent = nullptr;
+    it->second->rel_type = type;
+    it->second->rel_index = index;
+    it->second->count = count;
+    it->second->last_used_instruction = it->second->set_instruction;
+    it->second->rel_pinned = true;
     return ELEMENT_OK;
 }
 
 element_result compiler_state::calculate_stack_index(const element::instruction* in, uint16_t& index) const
 {
-    auto it = _allocations.find(in);
-    if (it == _allocations.end()) return ELEMENT_ERROR_NOT_FOUND;
-    index = calculate_stack_index(it->second->type(), it->second->index());
+    stack_allocation* alloc = allocator->get(in);
+    if (!alloc) return ELEMENT_ERROR_NOT_FOUND;
+    index = calculate_stack_index(alloc->type(), alloc->index());
     return ELEMENT_OK;
 }
 
@@ -97,7 +130,7 @@ uint16_t compiler_state::calculate_stack_index(const allocation_type type, uint1
     if (type == allocation_type::output)
         return index;
     // otherwise add outputs count
-    index += virtual_results[inst_indices.at(return_instruction)].count;
+    index += allocator->get(return_instruction)->count;
     // local stack index
     return index;
 }
@@ -126,17 +159,7 @@ element_result compiler_state::find_constant(element_value value, uint16_t& inde
     }
 }
 
-element_result compiler_state::find_virtual_result(const element::instruction* in, virtual_result& vr) const
-{
-    if (auto it = inst_indices.find(in); it != inst_indices.end() && it->second < virtual_results.size()) {
-        vr = virtual_results[it->second];
-        return ELEMENT_OK;
-    } else {
-        return ELEMENT_ERROR_NOT_FOUND;
-    }
-}
-
-uint16_t compiler_state::get_max_stack_usage() const
+uint16_t compiler_state::stack_allocator::get_max_stack_usage() const
 {
     uint16_t cur = 0;
     for (const auto& alloc : _allocations) {

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -1,0 +1,76 @@
+#include <algorithm>
+#include <vector>
+#include <unordered_map>
+
+#include "instruction_tree/instructions.hpp"
+#include "lmnt/compiler.hpp"
+
+struct virtual_result
+{
+    const element::instruction* instruction = nullptr;
+    uint16_t count = 0;
+    bool prepared = false;
+    bool is_output = false;
+};
+
+struct compiler_state;
+
+struct compiler_stack_info
+{
+    compiler_stack_info(const compiler_state& state) : _state(state) {}
+
+    element_result set_allocation(const element::instruction* in, uint16_t count);
+    element_result set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index);
+    element_result clear_allocation(const element::instruction* in);
+    element_result use_pinned_allocation(const element::instruction* in, uint16_t index, uint16_t count);
+    element_result use_allocation(const element::instruction* current_in, const element::instruction* alloc_in);
+    element_result get_stack_index(const element::instruction* in, uint16_t& index);
+    element_result set_stack_index(const element::instruction* in, uint16_t index);
+
+private:
+    struct stack_allocation
+    {
+        const element::instruction* originating_instruction;
+        uint16_t count;
+        size_t set_instruction;
+        size_t last_used_instruction;
+
+        std::shared_ptr<stack_allocation> parent = nullptr;
+        uint16_t stack_rel_index = 0;
+        bool pinned = false;
+        uint16_t pinned_index = 0;
+
+        uint16_t stack_index() const
+        {
+            return stack_rel_index + (parent ? parent->stack_index() : 0);
+        }
+    };
+
+    const compiler_state& _state;
+    std::unordered_map<const element::instruction*, std::shared_ptr<stack_allocation>> _allocations;
+};
+
+struct compiler_state
+{
+    compiler_state(const element_lmnt_compiler_ctx& c, std::vector<element_value> v, uint16_t icount)
+        : ctx(c)
+        , constants(std::move(v))
+        , inputs_count(icount)
+        , stack(*this)
+    {
+    }
+
+    const element_lmnt_compiler_ctx& ctx;
+    std::vector<element_value> constants;
+    uint16_t inputs_count;
+
+    compiler_stack_info stack;
+    std::unordered_map<const element::instruction*, size_t> results;
+    std::vector<virtual_result> virtual_results;
+    std::unordered_map<element_value, size_t> candidate_constants;
+
+    element_result add_constant(element_value value, uint16_t* index = nullptr);
+    element_result find_constant(element_value value, uint16_t& index);
+
+    element_result find_virtual_result(const element::instruction* in, virtual_result& vr);
+};

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -13,19 +13,48 @@ struct virtual_result
     bool is_output = false;
 };
 
-struct compiler_state;
-
-struct compiler_stack_info
+enum class allocation_type
 {
-    compiler_stack_info(const compiler_state& state) : _state(state) {}
+    constant,
+    input,
+    output,
+    local
+};
+
+struct compiler_state
+{
+    compiler_state(const element_lmnt_compiler_ctx& c, const element::instruction* in, std::vector<element_value>& v, uint16_t icount)
+        : ctx(c)
+        , return_instruction(in)
+        , constants(v)
+        , inputs_count(icount)
+    {
+    }
+
+    const element_lmnt_compiler_ctx& ctx;
+    const element::instruction* return_instruction;
+    std::vector<element_value>& constants;
+    uint16_t inputs_count;
+
+    std::unordered_map<const element::instruction*, size_t> results;
+    std::vector<virtual_result> virtual_results;
+    std::unordered_map<element_value, size_t> candidate_constants;
+
+    element_result add_constant(element_value value, uint16_t* index = nullptr);
+    element_result find_constant(element_value value, uint16_t& index);
+
+    element_result find_virtual_result(const element::instruction* in, virtual_result& vr);
+
 
     element_result set_allocation(const element::instruction* in, uint16_t count);
+    element_result set_allocation_if_not_pinned(const element::instruction* in, uint16_t count);
     element_result set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index);
     element_result clear_allocation(const element::instruction* in);
-    element_result use_pinned_allocation(const element::instruction* in, uint16_t index, uint16_t count);
+    element_result use_pinned_allocation(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count);
     element_result use_allocation(const element::instruction* current_in, const element::instruction* alloc_in);
+
+    uint16_t get_stack_index(const allocation_type type, uint16_t index);
     element_result get_stack_index(const element::instruction* in, uint16_t& index);
-    element_result set_stack_index(const element::instruction* in, uint16_t index);
 
 private:
     struct stack_allocation
@@ -36,41 +65,20 @@ private:
         size_t last_used_instruction;
 
         std::shared_ptr<stack_allocation> parent = nullptr;
-        uint16_t stack_rel_index = 0;
+        allocation_type cur_type = allocation_type::local;
+        uint16_t rel_index = 0;
         bool pinned = false;
-        uint16_t pinned_index = 0;
 
-        uint16_t stack_index() const
+        allocation_type type() const
         {
-            return stack_rel_index + (parent ? parent->stack_index() : 0);
+            return (parent) ? parent->type() : cur_type;
+        }
+
+        uint16_t index() const
+        {
+            return rel_index + (parent ? parent->index() : 0);
         }
     };
 
-    const compiler_state& _state;
     std::unordered_map<const element::instruction*, std::shared_ptr<stack_allocation>> _allocations;
-};
-
-struct compiler_state
-{
-    compiler_state(const element_lmnt_compiler_ctx& c, std::vector<element_value> v, uint16_t icount)
-        : ctx(c)
-        , constants(std::move(v))
-        , inputs_count(icount)
-        , stack(*this)
-    {
-    }
-
-    const element_lmnt_compiler_ctx& ctx;
-    std::vector<element_value> constants;
-    uint16_t inputs_count;
-
-    compiler_stack_info stack;
-    std::unordered_map<const element::instruction*, size_t> results;
-    std::vector<virtual_result> virtual_results;
-    std::unordered_map<element_value, size_t> candidate_constants;
-
-    element_result add_constant(element_value value, uint16_t* index = nullptr);
-    element_result find_constant(element_value value, uint16_t& index);
-
-    element_result find_virtual_result(const element::instruction* in, virtual_result& vr);
 };

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -5,6 +5,8 @@
 #include "instruction_tree/instructions.hpp"
 #include "lmnt/compiler.hpp"
 
+// represents a placeholder of space that (potentially) needs to be reserved for an instruction's result
+// this doesn't say anything about where it is on the stack or whether it actually needs reserving
 struct virtual_result
 {
     const element::instruction* instruction = nullptr;
@@ -41,10 +43,11 @@ struct compiler_state
     std::unordered_map<element_value, size_t> candidate_constants;
 
     element_result add_constant(element_value value, uint16_t* index = nullptr);
-    element_result find_constant(element_value value, uint16_t& index);
+    element_result find_constant(element_value value, uint16_t& index) const;
 
-    element_result find_virtual_result(const element::instruction* in, virtual_result& vr);
+    element_result find_virtual_result(const element::instruction* in, virtual_result& vr) const;
 
+    uint16_t get_max_stack_usage() const;
 
     element_result set_allocation(const element::instruction* in, uint16_t count);
     element_result set_allocation_if_not_pinned(const element::instruction* in, uint16_t count);
@@ -53,8 +56,8 @@ struct compiler_state
     element_result use_pinned_allocation(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count);
     element_result use_allocation(const element::instruction* current_in, const element::instruction* alloc_in);
 
-    uint16_t get_stack_index(const allocation_type type, uint16_t index);
-    element_result get_stack_index(const element::instruction* in, uint16_t& index);
+    uint16_t calculate_stack_index(const allocation_type type, uint16_t index) const;
+    element_result calculate_stack_index(const element::instruction* in, uint16_t& index) const;
 
 private:
     struct stack_allocation

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -85,7 +85,8 @@ struct compiler_state
 public:
     struct stack_allocator
     {
-        stack_allocation* get(const element::instruction* in) const;
+        stack_allocation* get(const element::instruction* in);
+        const stack_allocation* get(const element::instruction* in) const;
         element_result get_type(const element::instruction* in, allocation_type& type) const;
         bool is_type(const element::instruction* in, allocation_type type) const;
         element_result add(const element::instruction* in, size_t inst_idx, uint16_t count = 0, stack_allocation** result = nullptr);

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -106,8 +106,14 @@ public:
 
         uint16_t get_max_stack_usage() const;
 
-        element_result allocate(const element::instruction* in) { return allocate(in, 0); }
         virtual element_result allocate(const element::instruction* in, size_t index) = 0;
+
+        element_result allocate(const element::instruction* in)
+        {
+            for (size_t i = 0; i < count(in); ++i)
+                ELEMENT_OK_OR_RETURN(allocate(in, i));
+            return ELEMENT_OK;
+        }
 
         // TODO: knowledge of conditional execution etc, use scopes?
 

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <vector>
 #include <unordered_map>
@@ -5,8 +7,6 @@
 #include "instruction_tree/instructions.hpp"
 #include "lmnt/compiler.hpp"
 
-// represents a placeholder of space that (potentially) needs to be reserved for an instruction's result
-// this doesn't say anything about where it is on the stack or whether it actually needs reserving
 
 enum class compilation_stage
 {
@@ -17,13 +17,6 @@ enum class compilation_stage
     compiled
 };
 
-struct virtual_result
-{
-    const element::instruction* instruction = nullptr;
-    uint16_t count = 0;
-    compilation_stage stage = compilation_stage::none;
-};
-
 enum class allocation_type
 {
     constant,
@@ -32,66 +25,87 @@ enum class allocation_type
     local
 };
 
-struct compiler_state
+struct stack_allocation : std::enable_shared_from_this<stack_allocation>
 {
-    compiler_state(const element_lmnt_compiler_ctx& c, const element::instruction* in, std::vector<element_value>& v, uint16_t icount)
-        : ctx(c)
-        , return_instruction(in)
-        , constants(v)
-        , inputs_count(icount)
+    stack_allocation(const element::instruction* in, uint16_t count, size_t set_in, size_t last_in)
+        : instruction(in)
+        , count(count)
+        , set_instruction(set_in)
+        , last_used_instruction(last_in)
     {
     }
+
+    const element::instruction* instruction;
+    uint16_t count;
+    size_t set_instruction;
+    size_t last_used_instruction;
+
+    compilation_stage stage = compilation_stage::none;
+
+    std::shared_ptr<stack_allocation> parent = nullptr;
+    allocation_type rel_type = allocation_type::local;
+    uint16_t rel_index = 0;
+    bool rel_pinned = false;
+
+    allocation_type type() const
+    {
+        return (parent) ? parent->type() : rel_type;
+    }
+
+    bool pinned() const
+    {
+        return (parent) ? parent->pinned() : rel_pinned;
+    }
+
+    uint16_t index() const
+    {
+        return rel_index + (parent ? parent->index() : 0);
+    }
+};
+
+
+struct compiler_state
+{
+    compiler_state(const element_lmnt_compiler_ctx& c, const element::instruction* in, std::vector<element_value>& v, uint16_t icount);
 
     const element_lmnt_compiler_ctx& ctx;
     const element::instruction* return_instruction;
     std::vector<element_value>& constants;
     uint16_t inputs_count;
 
-    std::unordered_map<const element::instruction*, size_t> inst_indices;
-    std::vector<virtual_result> virtual_results;
+    size_t cur_instruction_index = 0;
     std::unordered_map<element_value, size_t> candidate_constants;
 
     element_result add_constant(element_value value, uint16_t* index = nullptr);
     element_result find_constant(element_value value, uint16_t& index) const;
 
-    element_result find_virtual_result(const element::instruction* in, virtual_result& vr) const;
-
-    uint16_t get_max_stack_usage() const;
-
-    element_result get_allocation_type(const element::instruction* in, allocation_type& type) const;
-    bool is_allocation_type(const element::instruction* in, allocation_type type) const;
-    element_result set_allocation(const element::instruction* in, uint16_t count);
-    element_result set_allocation_if_not_pinned(const element::instruction* in, uint16_t count);
-    element_result set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index);
-    element_result clear_allocation(const element::instruction* in);
-    element_result use_pinned_allocation(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count);
-    element_result use_allocation(const element::instruction* current_in, const element::instruction* alloc_in);
-
     uint16_t calculate_stack_index(const allocation_type type, uint16_t index) const;
     element_result calculate_stack_index(const element::instruction* in, uint16_t& index) const;
 
-    struct stack_allocation
+public:
+    struct stack_allocator
     {
-        const element::instruction* originating_instruction;
-        uint16_t count;
-        size_t set_instruction;
-        size_t last_used_instruction;
+        stack_allocation* get(const element::instruction* in) const;
+        element_result get_type(const element::instruction* in, allocation_type& type) const;
+        bool is_type(const element::instruction* in, allocation_type type) const;
+        element_result add(const element::instruction* in, size_t inst_idx, uint16_t count = 0, stack_allocation** result = nullptr);
+        element_result set_count(const element::instruction* in, uint16_t count);
+        element_result set_pinned(const element::instruction* in, allocation_type type, uint16_t index, uint16_t count);
+        element_result set_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index);
+        element_result erase(const element::instruction* in);
+        element_result use(const element::instruction* current_in, const element::instruction* alloc_in);
 
-        std::shared_ptr<stack_allocation> parent = nullptr;
-        allocation_type cur_type = allocation_type::local;
-        uint16_t rel_index = 0;
-        bool pinned = false;
+        uint16_t get_max_stack_usage() const;
 
-        allocation_type type() const
-        {
-            return (parent) ? parent->type() : cur_type;
-        }
+        virtual element_result allocate(const element::instruction* in) = 0;
 
-        uint16_t index() const
-        {
-            return rel_index + (parent ? parent->index() : 0);
-        }
+        // TODO: knowledge of conditional execution etc, use scopes?
+
+        virtual ~stack_allocator() = default;
+    protected:
+        std::vector<std::shared_ptr<stack_allocation>> _alloc_storage;
+        std::unordered_map<const element::instruction*, stack_allocation*> _allocations;
     };
 
-    std::unordered_map<const element::instruction*, std::shared_ptr<stack_allocation>> _allocations;
+    std::unique_ptr<stack_allocator> allocator;
 };

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -47,7 +47,7 @@ struct compiler_state
     std::vector<element_value>& constants;
     uint16_t inputs_count;
 
-    std::unordered_map<const element::instruction*, size_t> results;
+    std::unordered_map<const element::instruction*, size_t> inst_indices;
     std::vector<virtual_result> virtual_results;
     std::unordered_map<element_value, size_t> candidate_constants;
 
@@ -70,7 +70,6 @@ struct compiler_state
     uint16_t calculate_stack_index(const allocation_type type, uint16_t index) const;
     element_result calculate_stack_index(const element::instruction* in, uint16_t& index) const;
 
-private:
     struct stack_allocation
     {
         const element::instruction* originating_instruction;

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -7,12 +7,21 @@
 
 // represents a placeholder of space that (potentially) needs to be reserved for an instruction's result
 // this doesn't say anything about where it is on the stack or whether it actually needs reserving
+
+enum class compilation_stage
+{
+    none,
+    created,
+    prepared,
+    allocated,
+    compiled
+};
+
 struct virtual_result
 {
     const element::instruction* instruction = nullptr;
     uint16_t count = 0;
-    bool prepared = false;
-    bool is_output = false;
+    compilation_stage stage = compilation_stage::none;
 };
 
 enum class allocation_type
@@ -49,6 +58,8 @@ struct compiler_state
 
     uint16_t get_max_stack_usage() const;
 
+    element_result get_allocation_type(const element::instruction* in, allocation_type& type) const;
+    bool is_allocation_type(const element::instruction* in, allocation_type type) const;
     element_result set_allocation(const element::instruction* in, uint16_t count);
     element_result set_allocation_if_not_pinned(const element::instruction* in, uint16_t count);
     element_result set_allocation_parent(const element::instruction* child, const element::instruction* parent, uint16_t rel_index);

--- a/libelement/src/lmnt/naive_allocator.hpp
+++ b/libelement/src/lmnt/naive_allocator.hpp
@@ -4,23 +4,19 @@
 
 class naive_allocator : public compiler_state::stack_allocator
 {
-    element_result allocate(const element::instruction* in) override
+    element_result allocate(const element::instruction* in, size_t alloc_index) override
     {
-        stack_allocation* alloc = get(in);
+        stack_allocation* alloc = get(in, alloc_index);
         if (!alloc)
-        {
             return ELEMENT_ERROR_NOT_FOUND;
-        }
+
         // for inputs/outputs/constants, nothing to do
         if (alloc->type() != allocation_type::local || alloc->pinned())
-        {
             return ELEMENT_OK;
-        }
+
         // if this has a parent, leave it to that
         if (alloc->parent)
-        {
             return ELEMENT_OK;
-        }
 
         alloc->rel_index = cur_index;
         cur_index += alloc->count;

--- a/libelement/src/lmnt/naive_allocator.hpp
+++ b/libelement/src/lmnt/naive_allocator.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "lmnt/compiler_state.hpp"
+
+class naive_allocator : public compiler_state::stack_allocator
+{
+    element_result allocate(const element::instruction* in) override
+    {
+        stack_allocation* alloc = get(in);
+        if (!alloc)
+        {
+            return ELEMENT_ERROR_NOT_FOUND;
+        }
+        // for inputs/outputs/constants, nothing to do
+        if (alloc->type() != allocation_type::local || alloc->pinned())
+        {
+            return ELEMENT_OK;
+        }
+        // if this has a parent, leave it to that
+        if (alloc->parent)
+        {
+            return ELEMENT_OK;
+        }
+
+        alloc->rel_index = cur_index;
+        cur_index += alloc->count;
+        return ELEMENT_OK;
+    }
+
+private:
+    uint16_t cur_index = 0;
+};

--- a/libelement/src/object_model/compilation_context.hpp
+++ b/libelement/src/object_model/compilation_context.hpp
@@ -10,6 +10,9 @@
 //todo: move to cpp
 #include "declarations/function_declaration.hpp"
 
+//STD
+#include <set>
+
 namespace element
 {
     class compilation_context
@@ -28,6 +31,7 @@ namespace element
         struct boundary_info
         {
             size_t size = 0;
+            std::set<std::shared_ptr<const instruction_input>> inputs;
         };
 
         mutable std::vector<boundary_info> boundaries;

--- a/libelement/src/object_model/declarations/struct_declaration.cpp
+++ b/libelement/src/object_model/declarations/struct_declaration.cpp
@@ -132,6 +132,7 @@ object_const_shared_ptr struct_declaration::generate_placeholder(
         const auto* intrinsic = intrinsic::get_intrinsic(context.interpreter, *this);
         auto expr = std::make_shared<instruction_input>(boundary_scope, placeholder_index);
         expr->actual_type = intrinsic->get_type();
+        context.boundaries[boundary_scope].inputs.insert(expr);
         placeholder_index += 1; //todo: fix when we have lists, size() on intrinsic? on type?
         return expr;
     }

--- a/libelement/src/object_model/intrinsics/intrinsic_for.cpp
+++ b/libelement/src/object_model/intrinsics/intrinsic_for.cpp
@@ -152,7 +152,7 @@ object_const_shared_ptr runtime_for(const object_const_shared_ptr& initial_objec
     //everything is an instruction, so make a for instruction. note: initial_object is either Num or Bool.
     auto initial_expression = std::dynamic_pointer_cast<const instruction>(initial_object);
     if (initial_expression)
-        return std::make_shared<instruction_for>(std::move(initial_expression), std::move(predicate_expression), std::move(body_expression));
+        return std::make_shared<instruction_for>(std::move(initial_expression), std::move(predicate_expression), std::move(body_expression), context.boundaries.back().inputs);
 
     //if it wasn't an instruction, let's convert it in to one.
     //if we can't then this for-loop can't be done at runtime, since it can't be represented in the instruction tree
@@ -161,7 +161,7 @@ object_const_shared_ptr runtime_for(const object_const_shared_ptr& initial_objec
         return std::make_shared<const error>("tried to create a runtime for but a non-serializable initial value was given", ELEMENT_ERROR_UNKNOWN, source_info, context.get_logger());
 
     //initial_object should be a struct, so the output of the for loop is going to be the same type of struct, except all the fields (flattened struct) are instructions referring to the for loop
-    const auto for_expression = std::make_shared<element::instruction_for>(std::move(initial_expression), std::move(predicate_expression), std::move(body_expression));
+    const auto for_expression = std::make_shared<element::instruction_for>(std::move(initial_expression), std::move(predicate_expression), std::move(body_expression), context.boundaries.back().inputs);
     const auto initial_struct = std::dynamic_pointer_cast<const struct_instance>(initial_object);
 
     auto indexing_expression_filler = [&for_expression](const std::string&,

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -154,10 +154,10 @@ int main(int argc, char** argv)
     element_interpreter_set_log_callback(context, log_callback, nullptr);
     element_interpreter_load_prelude(context);
 
-    float outputs[1];
+    float* outputs = nullptr;
 
-    element_inputs input;
-    element_outputs output;
+    element_inputs input = { nullptr, 0 };
+    element_outputs output = { nullptr, 0 };
 
     std::array<char, 2048> output_buffer_array{};
     char* output_buffer = output_buffer_array.data();
@@ -198,8 +198,8 @@ int main(int argc, char** argv)
     input.values = args.data();
     input.count = args.size();
 
-    output.values = outputs;
-    output.count = 1;
+    output.count = instruction->instruction->get_size();
+    output.values = new float[output.count];
 
     result = element_interpreter_evaluate_instruction(context, econtext, instruction, &input, &output);
     if (result != ELEMENT_OK)
@@ -297,6 +297,7 @@ cleanup:
     element_declaration_delete(&declaration);
     element_instruction_delete(&instruction);
     element_interpreter_delete(&context);
+    delete[] output.values;
     if (result != ELEMENT_OK)
     {
         printf("ELEMENT ERROR: %d\n", result);

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -138,6 +138,7 @@ int main(int argc, char** argv)
         printf("Usage: %s <function-definition> [<input> ...]", argv[0]);
         return 1;
     }
+
     std::vector<element_value> args;
     for (size_t i = 2; i < argc; ++i)
         args.emplace_back(std::stof(argv[i]));
@@ -146,6 +147,8 @@ int main(int argc, char** argv)
     element_evaluator_ctx* econtext = nullptr;
     element_declaration* declaration = nullptr;
     element_instruction* instruction = nullptr;
+
+    element_result result = ELEMENT_OK;
 
     ELEMENT_OK_OR_RETURN(element_interpreter_create(&context));
     element_interpreter_set_log_callback(context, log_callback, nullptr);
@@ -166,10 +169,17 @@ int main(int argc, char** argv)
     lmnt_validation_result lvresult = LMNT_VALIDATION_OK;
     const char* loperation = "nothing lol";
 
-    element_result result = element_interpreter_load_string(context, argv[1], "<input>");
+    result = element_interpreter_load_package(context, "StandardLibrary");
     if (result != ELEMENT_OK)
     {
-        printf("Output buffer too small");
+        printf("whoops, no stdlib: %d\n", result);
+        goto cleanup;
+    }
+
+    result = element_interpreter_load_string(context, argv[1], "<input>");
+    if (result != ELEMENT_OK)
+    {
+        printf("Output buffer too small\n");
         goto cleanup;
     }
 

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -56,7 +56,7 @@ void log_callback(const element_log_message* msg, void* user_data)
 }
 
 
-static std::vector<char> create_archive(const char* def_name, uint16_t args_count, uint16_t rvals_count, uint16_t stack_count, std::vector<lmnt_value> constants, std::vector<lmnt_instruction> function)
+static std::vector<char> create_archive(const char* def_name, uint16_t args_count, uint16_t rvals_count, uint16_t stack_count, const std::vector<lmnt_value>& constants, const std::vector<lmnt_instruction>& function)
 {
     const size_t name_len = strlen(def_name);
     const size_t instr_count = function.size();
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
     char* output_buffer = output_buffer_array.data();
 
     element_lmnt_compiler_ctx lmnt_ctx;
-    std::vector<lmnt_instruction> lmnt_output;
+    element_lmnt_compiled_function lmnt_output;
     std::vector<element_value> constants;
     lmnt_result lresult = LMNT_OK;
     const char* loperation = "nothing lol";
@@ -213,14 +213,13 @@ int main(int argc, char** argv)
         goto cleanup;
     }
 
-    for (const auto& in : lmnt_output)
+    for (const auto& in : lmnt_output.instructions)
     {
         printf("Instruction: %s %04X %04X %04X\n", lmnt_get_opcode_info(in.opcode)->name, in.arg1, in.arg2, in.arg3);
     }
 
     {
-        uint16_t stack_count = 8; // TODO: be able to get this out
-        auto lmnt_archive_data = create_archive("evaluate", args.size(), output.count, stack_count, constants, lmnt_output);
+        auto lmnt_archive_data = create_archive("evaluate", args.size(), output.count, lmnt_output.required_stack_count, constants, lmnt_output.instructions);
 
         std::vector<char> lmnt_stack(32768);
         lmnt_ictx lctx;

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
     if (result != ELEMENT_OK)
         goto cleanup;
 
-    sprintf(output_buffer + strlen(output_buffer), "%s -> {", argv[1]);
+    sprintf(output_buffer + strlen(output_buffer), "Element: %s -> {", argv[1]);
     for (int i = 0; i < output.count; ++i)
     {
         sprintf(output_buffer + strlen(output_buffer), "%f", output.values[i]);
@@ -215,10 +215,10 @@ int main(int argc, char** argv)
         goto cleanup;
     }
 
-    for (const auto& in : lmnt_output.instructions)
-    {
-        printf("Instruction: %s %04X %04X %04X\n", lmnt_get_opcode_info(in.opcode)->name, in.arg1, in.arg2, in.arg3);
-    }
+    // for (const auto& in : lmnt_output.instructions)
+    // {
+    //     printf("Instruction: %s %04X %04X %04X\n", lmnt_get_opcode_info(in.opcode)->name, in.arg1, in.arg2, in.arg3);
+    // }
 
     printf("Inputs: %zu, outputs: %zu, locals: %zu\n", lmnt_output.inputs_count, lmnt_output.outputs_count, lmnt_output.local_stack_count);
 
@@ -249,6 +249,9 @@ int main(int argc, char** argv)
             printf("LMNT validation error: %d\n", lvresult);
             goto lmnt_error;
         }
+
+        printf("\n");
+        lmnt_archive_print(&lctx.archive);
 
         loperation = "def search";
         printf("lmnt: doing %s\n", loperation);

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -1,0 +1,282 @@
+#include "element/common.h"
+#include "element/interpreter.h"
+#include "lmnt/opcodes.h"
+#include "lmnt/archive.h"
+#include "lmnt/interpreter.h"
+
+#include "interpreter_internal.hpp"
+#include "lmnt/compiler.hpp"
+
+#include <array>
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
+void log_callback(const element_log_message* msg, void* user_data)
+{
+    //TODO: This is a bit of a hack for now... Setting a constant length instead and using for both buffers
+    const auto space = 512;
+    char buffer[space];
+    buffer[0] = '^';
+    buffer[1] = '\0';
+    const char* buffer_str = nullptr;
+    if (msg->character - 1 >= 0)
+    {
+        const auto padding_count = msg->character - 1;
+        for (auto i = 0; i < padding_count; ++i)
+        {
+            buffer[i] = ' ';
+        }
+
+        const auto end = padding_count + msg->length;
+        for (auto i = padding_count; i < end; ++i)
+        {
+            buffer[i] = '^';
+        }
+
+        buffer[end] = '\0';
+
+        buffer_str = &buffer[0];
+    }
+
+    std::vector<char> output_buffer_array;
+    output_buffer_array.resize((size_t)msg->message_length + 4 * space);
+    auto* const output_buffer = output_buffer_array.data();
+
+    sprintf(output_buffer, "\n----------ELE%d %s\n%d| %s\n%d| %s\n\n%s\n----------\n\n",
+            msg->message_code,
+            msg->filename,
+            msg->line,
+            msg->line_in_source ? msg->line_in_source : "",
+            msg->line,
+            buffer_str,
+            msg->message);
+
+    printf("%s", output_buffer);
+}
+
+
+static std::vector<char> create_archive(const char* def_name, uint16_t args_count, uint16_t rvals_count, uint16_t stack_count, std::vector<lmnt_value> constants, std::vector<lmnt_instruction> function)
+{
+    const size_t name_len = strlen(def_name);
+    const size_t instr_count = function.size();
+    const size_t consts_count = constants.size();
+    const size_t data_count = 0;
+    assert(name_len <= 0xFE);
+    assert(instr_count <= 0x3FFFFFF0);
+    assert(consts_count <= 0x3FFFFFFF);
+
+    const size_t header_len = 0x1C;
+    const size_t strings_len = 0x02 + name_len + 1;
+    const size_t defs_len = 0x15;
+    uint32_t code_len = 0x04 + instr_count * sizeof(lmnt_instruction);
+    const uint32_t code_padding = (4 - ((header_len + strings_len + defs_len + code_len) % 4)) % 4;
+    code_len += code_padding;
+    const lmnt_loffset data_sec_count = 0;
+    uint32_t data_len = 0x04 + data_sec_count * (0x08 + 0x04 * data_count);
+    const uint32_t consts_len = consts_count * sizeof(lmnt_value);
+
+    const size_t total_size = header_len + strings_len + defs_len + code_len + data_len + consts_len;
+    std::vector<char> buf;
+    buf.resize(total_size);
+
+    size_t idx = 0;
+    const char header[] = {
+        'L', 'M', 'N', 'T',
+        0x00, 0x00, 0x00, 0x00,
+        strings_len & 0xFF, (strings_len >> 8) & 0xFF, (strings_len >> 16) & 0xFF, (strings_len >> 24) & 0xFF, // strings length
+        defs_len & 0xFF, (defs_len >> 8) & 0xFF, (defs_len >> 16) & 0xFF, (defs_len >> 24) & 0xFF,             // defs length
+        code_len & 0xFF, (code_len >> 8) & 0xFF, (code_len >> 16) & 0xFF, (code_len >> 24) & 0xFF,             // code length
+        data_len & 0xFF, (data_len >> 8) & 0xFF, (data_len >> 16) & 0xFF, (data_len >> 24) & 0xFF,             // data length
+        consts_len & 0xFF, (consts_len >> 8) & 0xFF, (consts_len >> 16) & 0xFF, (consts_len >> 24) & 0xFF      // constants_length
+    };
+    memcpy(buf.data() + idx, header, sizeof(header));
+    idx += sizeof(header);
+
+    buf[idx] = (name_len + 1) & 0xFF;
+    idx += 2;
+
+    memcpy(buf.data() + idx, def_name, name_len);
+    idx += name_len;
+    buf[idx++] = '\0';
+
+    const char def[] = {
+        0x15, 0x00,                                    // defs[0].length
+        0x00, 0x00,                                    // defs[0].name
+        0x00, 0x00,                                    // defs[0].flags
+        0x00, 0x00, 0x00, 0x00,                        // defs[0].code
+        stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_unaligned
+        stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_aligned
+        0x00, 0x00,                                    // defs[0].base_args_count
+        args_count & 0xFF, (args_count >> 8) & 0xFF,   // defs[0].args_count
+        rvals_count & 0xFF, (rvals_count >> 8) & 0xFF, // defs[0].rvals_count
+        0x00                                           // defs[0].bases_count
+    };
+    memcpy(buf.data() + idx, def, sizeof(def));
+    idx += sizeof(def);
+
+    memcpy(buf.data() + idx, (const char*)(&instr_count), sizeof(uint32_t));
+    idx += sizeof(uint32_t);
+
+    memcpy(buf.data() + idx, function.data(), instr_count * sizeof(lmnt_instruction));
+    idx += instr_count * sizeof(lmnt_instruction);
+
+    idx += code_padding;
+    memcpy(buf.data() + idx, (const char*)(&data_sec_count), sizeof(lmnt_loffset));
+    idx += sizeof(lmnt_loffset);
+
+    memcpy(buf.data() + idx, constants.data(), consts_count * sizeof(lmnt_value));
+    idx += consts_count * sizeof(lmnt_value);
+
+    assert(idx == total_size);
+
+    return buf;
+}
+
+
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        printf("give me something to run!\n");
+        printf("Usage: %s <function-definition> [<input> ...]");
+        return 1;
+    }
+    std::vector<element_value> args;
+    for (size_t i = 2; i < argc; ++i)
+        args.emplace_back(std::stof(argv[i]));
+
+    element_interpreter_ctx* context = nullptr;
+    element_declaration* declaration = nullptr;
+    element_instruction* instruction = nullptr;
+
+    ELEMENT_OK_OR_RETURN(element_interpreter_create(&context));
+    element_interpreter_set_log_callback(context, log_callback, nullptr);
+    element_interpreter_load_prelude(context);
+
+    float outputs[1];
+
+    element_inputs input;
+    element_outputs output;
+
+    std::array<char, 2048> output_buffer_array{};
+    char* output_buffer = output_buffer_array.data();
+
+    element_lmnt_compiler_ctx lmnt_ctx;
+    std::vector<lmnt_instruction> lmnt_output;
+    std::vector<element_value> constants;
+    lmnt_result lresult = LMNT_OK;
+    const char* loperation = "nothing lol";
+
+    element_result result = element_interpreter_load_string(context, argv[1], "<input>");
+    if (result != ELEMENT_OK)
+    {
+        printf("Output buffer too small");
+        goto cleanup;
+    }
+
+    result = element_interpreter_find(context, "evaluate", &declaration);
+    if (result != ELEMENT_OK)
+        goto cleanup;
+
+    result = element_interpreter_compile_declaration(context, NULL, declaration, &instruction);
+    if (result != ELEMENT_OK)
+        goto cleanup;
+
+    input.values = args.data();
+    input.count = args.size();
+
+    output.values = outputs;
+    output.count = 1;
+
+    result = element_interpreter_evaluate_instruction(context, NULL, instruction, &input, &output);
+    if (result != ELEMENT_OK)
+        goto cleanup;
+
+    sprintf(output_buffer + strlen(output_buffer), "%s -> {", argv[1]);
+    for (int i = 0; i < output.count; ++i)
+    {
+        sprintf(output_buffer + strlen(output_buffer), "%f", output.values[i]);
+        if (i != output.count - 1)
+        {
+            sprintf(output_buffer + strlen(output_buffer), ", ");
+        }
+    }
+    sprintf(output_buffer + strlen(output_buffer), "}\n");
+
+    printf("%s", output_buffer);
+
+    result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, constants, args.size(), lmnt_output);
+    if (result != ELEMENT_OK)
+    {
+        printf("RUH ROH: %d\n", result);
+        goto cleanup;
+    }
+
+    for (const auto& in : lmnt_output)
+    {
+        printf("Instruction: %s %04X %04X %04X\n", lmnt_get_opcode_info(in.opcode)->name, in.arg1, in.arg2, in.arg3);
+    }
+
+    {
+        uint16_t stack_count = 8; // TODO: be able to get this out
+        auto lmnt_archive_data = create_archive("evaluate", args.size(), output.count, stack_count, constants, lmnt_output);
+
+        std::vector<char> lmnt_stack(32768);
+        lmnt_ictx lctx;
+        lmnt_result lresult;
+
+        loperation = "ictx init";
+        printf("doing %s\n", loperation);
+        lresult = lmnt_ictx_init(&lctx, lmnt_stack.data(), lmnt_stack.size());
+        if (lresult != LMNT_OK)
+            goto lmnt_error;
+            
+        loperation = "archive load";
+        printf("doing %s\n", loperation);
+        lresult = lmnt_ictx_load_archive(&lctx, lmnt_archive_data.data(), lmnt_archive_data.size());
+        if (lresult != LMNT_OK)
+            goto lmnt_error;
+
+        loperation = "archive prepare";
+        printf("doing %s\n", loperation);
+        lresult = lmnt_ictx_prepare_archive(&lctx, nullptr);
+        if (lresult != LMNT_OK)
+            goto lmnt_error;
+
+        loperation = "def search";
+        printf("doing %s\n", loperation);
+        const lmnt_def* def = nullptr;
+        lresult = lmnt_ictx_find_def(&lctx, "evaluate", &def);
+        if (lresult != LMNT_OK)
+            goto lmnt_error;
+
+        loperation = "setting args";
+        printf("%s\n", loperation);
+        lresult = lmnt_update_args(&lctx, def, 0, args.data(), args.size());
+        if (lresult != LMNT_OK)
+            goto lmnt_error;
+
+        loperation = "executing def";
+        printf("%s\n", loperation);
+        std::vector<lmnt_value> lmnt_results(output.count);
+        lresult = lmnt_execute(&lctx, def, lmnt_results.data(), lmnt_results.size());
+        if (lresult != lmnt_results.size())
+            goto lmnt_error;
+
+        for (size_t i = 0; i < lmnt_results.size(); ++i)
+            printf("lmnt_results[%zu]: %f\n", i, lmnt_results[i]);
+    }
+
+lmnt_error:
+    if (lresult != LMNT_OK)
+    {
+        printf("LMNT ERROR during %s: %d\n", loperation, lresult);
+    }
+
+cleanup:
+    element_declaration_delete(&declaration);
+    element_instruction_delete(&instruction);
+    element_interpreter_delete(&context);
+    return result;
+}


### PR DESCRIPTION
- Adds a fairly-complete compiler from Element instruction trees to LMNT bytecode
    - Passes almost all tests that libelement's interpreter does
    - Adds support for libelement.CLI executing via other targets such as LMNT (with or without the JIT)
- Several LMNT changes
    - Adds the `CMPZ` instruction to compare a value to zero
    - Changes `MINxx`/`MAXxx` instructions to use C/C++ style min/max behaviour, not that of `fminf`/`fmaxf`
        - This only affects behaviour when one argument is NaN
    - Adds debug option to print each instruction evaluated and the state of the stack/flags at that point
    - Small performance improvements via more use of `LMNT_LIKELY`/`LMNT_UNLIKELY`
- Adds support to Laboratory for running test executables with additional arguments