### PR TITLE
libelement: [LMNT] improvements to conditional execution

### DIFF
--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -717,7 +717,7 @@ static element_result allocate_virtual_for(
 using input_set = std::set<std::shared_ptr<const element::instruction_input>>;
 static element_result find_input_allocations(const compiler_state& state, const element::instruction* in, const input_set& expected, std::vector<const stack_allocation*>& result)
 {
-    const auto* input = dynamic_cast<const element::instruction_input*>(in);
+    const auto* input = in->as<element::instruction_input>();
     if (input && std::find_if(expected.begin(), expected.end(), [&](const auto& e) { return e.get() == input; }) != expected.end())
     {
         if (result.size() <= input->index())
@@ -811,7 +811,7 @@ static element_result prepare_virtual_indexer(
     compiler_state& state,
     const element::instruction_indexer& ei)
 {
-    const element::instruction_for* ef = dynamic_cast<const element::instruction_for*>(ei.for_instruction().get());
+    const element::instruction_for* ef = ei.for_instruction()->as<element::instruction_for>();
     if (!ef) return ELEMENT_ERROR_UNKNOWN;
 
     stack_allocation* ef_alloc = nullptr;

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -1246,8 +1246,11 @@ static element_result compile_instruction(
     if (!vr) return ELEMENT_ERROR_UNKNOWN;
 
     // only skip re-emitting bytecode if we've definitely already executed it
-    if (vr->stage >= compilation_stage::compiled && vr->executed_in == execution_type::unconditional)
+    if (vr->stage >= compilation_stage::compiled
+        && (vr->executed_in == execution_type::unconditional || state.current_context->compiled_instructions.count(expr)))
+    {
         return ELEMENT_OK;
+    }
 
     uint16_t index;
     ELEMENT_OK_OR_RETURN(state.calculate_stack_index(expr, index));
@@ -1287,6 +1290,7 @@ static element_result compile_instruction(
     if (oresult == ELEMENT_OK)
     {
         state.allocator->set_stage(expr, compilation_stage::compiled);
+        state.current_context->compiled_instructions.emplace(expr);
     }
 
     return oresult;

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -706,10 +706,7 @@ static element_result create_virtual_for(
     stack_allocation* body_vr;
 
     ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.initial().get(), &initial_vr));
-
-    ELEMENT_OK_OR_RETURN(state.push_context(ef.condition().get(), execution_type::unconditional));
     ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.condition().get(), &condition_vr));
-    ELEMENT_OK_OR_RETURN(state.pop_context());
 
     ELEMENT_OK_OR_RETURN(state.push_context(ef.body().get(), execution_type::conditional));
     ELEMENT_OK_OR_RETURN(create_virtual_result(state, ef.body().get(), &body_vr));
@@ -732,10 +729,7 @@ static element_result prepare_virtual_for(
     const element::instruction* dep2 = ef.body().get();
 
     ELEMENT_OK_OR_RETURN(prepare_virtual_result(state, dep0));
-
-    ELEMENT_OK_OR_RETURN(state.push_context(dep1, execution_type::unconditional));
     ELEMENT_OK_OR_RETURN(prepare_virtual_result(state, dep1));
-    ELEMENT_OK_OR_RETURN(state.pop_context());
 
     ELEMENT_OK_OR_RETURN(state.push_context(dep2, execution_type::conditional));
     ELEMENT_OK_OR_RETURN(prepare_virtual_result(state, dep2));
@@ -756,10 +750,7 @@ static element_result allocate_virtual_for(
     const element::instruction_for& ef)
 {
     ELEMENT_OK_OR_RETURN(allocate_virtual_result(state, ef.initial().get()));
-
-    ELEMENT_OK_OR_RETURN(state.push_context(ef.condition().get(), execution_type::unconditional));
     ELEMENT_OK_OR_RETURN(allocate_virtual_result(state, ef.condition().get()));
-    ELEMENT_OK_OR_RETURN(state.pop_context());
 
     ELEMENT_OK_OR_RETURN(state.push_context(ef.body().get(), execution_type::conditional));
     ELEMENT_OK_OR_RETURN(allocate_virtual_result(state, ef.body().get()));
@@ -820,9 +811,7 @@ static element_result compile_for(
     }
 
     // compile condition logic
-    ELEMENT_OK_OR_RETURN(state.push_context(ef.condition().get(), execution_type::unconditional));
     ELEMENT_OK_OR_RETURN(compile_instruction(state, condition_vr->instruction, output));
-    ELEMENT_OK_OR_RETURN(state.pop_context());
     output.emplace_back(lmnt_instruction{LMNT_OP_CMPZ, condition_stack_idx, 0, 0});
     const size_t condition_branchcle_idx = output.size();
     output.emplace_back(lmnt_instruction{LMNT_OP_BRANCHCLE, 0, 0, 0}); // target filled in at the end

--- a/libelement/src/lmnt/compiler_state.cpp
+++ b/libelement/src/lmnt/compiler_state.cpp
@@ -6,6 +6,8 @@ compiler_state::compiler_state(const element_lmnt_compiler_ctx& c, const element
     , return_instruction(in)
     , constants(v)
     , inputs_count(icount)
+    , contexts({{ in, execution_context(nullptr, execution_type::unconditional) }})
+    , current_context(&contexts.at(in))
 {
     // TODO: better allocators
     allocator = std::make_unique<naive_allocator>();
@@ -187,4 +189,41 @@ uint16_t compiler_state::stack_allocator::get_max_stack_usage() const
         }
     }
     return cur;
+}
+
+element_result compiler_state::push_context(const element::instruction* in, execution_type type)
+{
+    auto it = contexts.try_emplace(in, current_context, type).first;
+    if (it->second.rel_type != type)
+        return ELEMENT_ERROR_UNKNOWN;
+    current_context = &it->second;
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::pop_context()
+{
+    if (!current_context || !current_context->parent)
+        return ELEMENT_ERROR_UNKNOWN;
+    current_context = current_context->parent;
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::use_in_context(const element::instruction* in)
+{
+    for (size_t i = 0; i < allocator->count(in); ++i)
+    {
+        stack_allocation* a = allocator->get(in, i);
+        a->set_executed_in(current_context->type());
+        current_context->allocations.emplace(a);
+    }
+    return ELEMENT_OK;
+}
+
+element_result compiler_state::use(const element::instruction* current_in, size_t current_index, const element::instruction* alloc_in, size_t alloc_index)
+{
+    stack_allocation* alloc = allocator->get(alloc_in, alloc_index);
+    if (!alloc) return ELEMENT_ERROR_UNKNOWN;
+    current_context->allocations.emplace(alloc);
+
+    return allocator->use(current_in, current_index, alloc_in, alloc_index);
 }

--- a/libelement/src/lmnt/compiler_state.hpp
+++ b/libelement/src/lmnt/compiler_state.hpp
@@ -86,6 +86,7 @@ struct execution_context
     execution_context* const parent;
     const execution_type rel_type;
     std::unordered_set<const stack_allocation*> allocations;
+    std::unordered_set<const element::instruction*> compiled_instructions;
 
     execution_type type() const { return (parent ? (std::min)(rel_type, parent->type()) : rel_type); }
 };


### PR DESCRIPTION
Fairly naive pass at making conditional execution work properly.

The problem before can be shown by the example:
```
_(a:Num):Num
{
    x = a.sub(5)
    y = if(true, a, x)
    return = y.sub(x)
}
```
When we generate bytecode, previously we have compiled it once at the first place it's used, and then reused the result. If that first use is only executed conditionally (as above), then it breaks - `y.sub(x)` just goes and grabs a result for `x` that was never calculated because the `if` didn't go that way.

This change adds the concept of "execution contexts" to the compiler; each level of branching effectively adds a new context. This allows us to make better decisions about when a result has definitely been calculated or whether we need to do it again.

There are a few TODOs left because we can still make much smarter decisions than we currently are, and I've got a commit to (hopefully) do so, but I'm unable to test it at the moment due to libelement's limited CSE.