### PR TITLE
LMNT: add backbranches flag to function definitions

### DIFF
--- a/LMNT/doc/Bytecode.md
+++ b/LMNT/doc/Bytecode.md
@@ -87,6 +87,11 @@ struct {
 
 The table consists of a set of these entries, with no intermediate padding.
 
+The set of flags which may apply to a function definition are:
+
+* `LMNT_DEFFLAG_EXTERN`: the function has an external definition which the LMNT host may have knowledge of
+* `LMNT_DEFFLAG_INTERFACE`: the function has no body, and thus to be callable it must have a valid external definition
+* `LMNT_DEFFLAG_HAS_BACKBRANCHES`: the function contains backward-facing branches (e.g. looping) and thus has no guarantee of halting
 
 ### Code Table
 

--- a/LMNT/include/lmnt/archive.h
+++ b/LMNT/include/lmnt/archive.h
@@ -44,10 +44,10 @@ typedef struct lmnt_archive_header
 typedef uint16_t lmnt_def_flags;
 enum
 {
-    LMNT_DEFFLAG_NONE      = (0U << 0),
-    LMNT_DEFFLAG_INTERFACE = (1U << 0),
-    LMNT_DEFFLAG_EXTERN    = (1U << 1),
-    LMNT_DEFFLAG_LAMBDA    = (1U << 2),
+    LMNT_DEFFLAG_NONE             = (0U << 0),
+    LMNT_DEFFLAG_INTERFACE        = (1U << 0),
+    LMNT_DEFFLAG_EXTERN           = (1U << 1),
+    LMNT_DEFFLAG_HAS_BACKBRANCHES = (1U << 2),
 };
 
 typedef struct lmnt_def

--- a/LMNT/src/validation.c
+++ b/LMNT/src/validation.c
@@ -75,7 +75,7 @@ static int32_t validate_def_inner(const lmnt_archive* archive, lmnt_offset def_i
 
     // If interface/extern, check we have zero locals
     const lmnt_offset computed_stack_count = dhdr->args_count + dhdr->rvals_count;
-    if ((dhdr->flags | (LMNT_DEFFLAG_EXTERN & LMNT_DEFFLAG_INTERFACE)) != 0 && dhdr->stack_count_unaligned != computed_stack_count)
+    if ((dhdr->flags & (LMNT_DEFFLAG_EXTERN | LMNT_DEFFLAG_INTERFACE)) != 0 && dhdr->stack_count_unaligned != computed_stack_count)
         return LMNT_VERROR_DEF_HEADER;
     return sizeof(lmnt_def);
 }

--- a/LMNT/test/CMakeLists.txt
+++ b/LMNT/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(FetchCUnit)
 
 set(test_headers
+    "test_archive.h"
     "test_bounds.h"
     "test_branch.h"
     "test_fncall.h"

--- a/LMNT/test/test_archive.h
+++ b/LMNT/test/test_archive.h
@@ -1,0 +1,68 @@
+#include "CUnit/CUnitCI.h"
+#include "lmnt/interpreter.h"
+#include "testhelpers.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+#if !defined(TESTSETUP_INCLUDED)
+#error "This file cannot be included without a testsetup header already having been included"
+#endif
+
+
+static void test_archive_backbranches(void)
+{
+    archive a = create_archive_array_with_flags("test", LMNT_DEFFLAG_HAS_BACKBRANCHES, 1, 1, 2, 4, 0, 2,
+        LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x02, 0x00, 0x02),
+        LMNT_OP_BYTES(LMNT_OP_CMP, 0x02, 0x01, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT, 0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x10, 0x00, 0x03),
+        1.0, 5.0
+    );
+    test_function_data fndata = { NULL, NULL };
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    lmnt_value rvals[1];
+    const size_t rvals_count = sizeof(rvals)/sizeof(lmnt_value);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 16.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+
+
+    a = create_archive_array_with_flags("test", LMNT_DEFFLAG_NONE, 1, 1, 2, 4, 0, 2,
+        LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x02, 0x00, 0x02),
+        LMNT_OP_BYTES(LMNT_OP_CMP, 0x02, 0x01, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT, 0x00, 0x00, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x10, 0x00, 0x03),
+        1.0, 5.0
+    );
+    TEST_LOAD_ARCHIVE_FAILS_VALIDATION(ctx, "test", a, fndata, LMNT_ERROR_INVALID_ARCHIVE, LMNT_VERROR_DEF_FLAGS);
+    delete_archive_array(a);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+
+
+    a = create_archive_array_with_flags("test", LMNT_DEFFLAG_NONE, 1, 1, 2, 4, 0, 2,
+        LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x02, 0x00, 0x02),
+        LMNT_OP_BYTES(LMNT_OP_CMP, 0x02, 0x01, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_BRANCHCLT, 0x00, 0x03, 0x00),
+        LMNT_OP_BYTES(LMNT_OP_ASSIGNIIS, 0x10, 0x00, 0x03),
+        1.0, 5.0
+    );
+    TEST_LOAD_ARCHIVE(ctx, "test", a, fndata);
+    delete_archive_array(a);
+
+    TEST_UPDATE_ARGS(ctx, fndata, 0, 0.0f);
+    CU_ASSERT_EQUAL(TEST_EXECUTE(ctx, fndata, rvals, rvals_count), rvals_count);
+    CU_ASSERT_DOUBLE_EQUAL(rvals[0], 16.0, FLOAT_ERROR_MARGIN);
+
+    TEST_UNLOAD_ARCHIVE(ctx, a, fndata);
+}
+
+
+MAKE_REGISTER_SUITE_FUNCTION(archive,
+    CUNIT_CI_TEST(test_archive_backbranches)
+);

--- a/LMNT/test/test_interpreter.c
+++ b/LMNT/test/test_interpreter.c
@@ -1,5 +1,6 @@
 #include "testsetup_interpreter.h"
 
+#include "test_archive.h"
 #include "test_maths_scalar.h"
 #include "test_maths_vector.h"
 #include "test_bounds.h"
@@ -11,6 +12,7 @@
 
 int main(int argc, char** argv)
 {
+    register_suite_archive();
     register_suite_maths_scalar();
     register_suite_maths_vector();
     register_suite_bounds();

--- a/LMNT/test/test_jit_native.c
+++ b/LMNT/test/test_jit_native.c
@@ -1,5 +1,6 @@
 #include "testsetup_jit_native.h"
 
+#include "test_archive.h"
 #include "test_maths_scalar.h"
 #include "test_maths_vector.h"
 #include "test_bounds.h"
@@ -11,6 +12,7 @@
 
 int main(int argc, char** argv)
 {
+    register_suite_archive();
     register_suite_maths_scalar();
     register_suite_maths_vector();
     register_suite_bounds();

--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -292,7 +292,8 @@ namespace libelement::cli
             uint16_t rvals_count,
             uint16_t stack_count,
             const std::vector<lmnt_value>& constants,
-            const std::vector<lmnt_instruction>& function)
+            const std::vector<lmnt_instruction>& function,
+            const lmnt_def_flags flags)
         {
             const size_t name_len = strlen(def_name);
             const size_t name_len_padded = LMNT_ROUND_UP(0x02 + name_len + 1, 4) - 2;
@@ -338,7 +339,7 @@ namespace libelement::cli
 
             const char def[] = {
                 0x00, 0x00,                                    // defs[0].name
-                0x00, 0x00,                                    // defs[0].flags
+                flags & 0xFF, (flags >> 8) & 0xFF,             // defs[0].flags
                 0x00, 0x00, 0x00, 0x00,                        // defs[0].code
                 stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_unaligned
                 stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_aligned
@@ -394,7 +395,7 @@ namespace libelement::cli
             }
 
             {
-                auto lmnt_archive_data = create_archive("evaluate", uint16_t(input.count), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions);
+                auto lmnt_archive_data = create_archive("evaluate", uint16_t(input.count), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions, lmnt_output.flags);
 
                 std::vector<char> lmnt_stack(32768);
                 lmnt_ictx lctx;

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -20,9 +20,10 @@ struct element_lmnt_compiler_ctx
 struct element_lmnt_compiled_function
 {
     std::vector<lmnt_instruction> instructions;
-    size_t local_stack_count;
-    size_t inputs_count;
-    size_t outputs_count;
+    size_t local_stack_count = 0;
+    size_t inputs_count = 0;
+    size_t outputs_count = 0;
+    lmnt_def_flags flags = LMNT_DEFFLAG_NONE;
 
     size_t total_stack_count() const { return inputs_count + outputs_count + local_stack_count; }
 };

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -56,7 +56,7 @@ void log_callback(const element_log_message* msg, void* user_data)
 }
 
 
-static std::vector<char> create_archive(const char* def_name, uint16_t args_count, uint16_t rvals_count, uint16_t stack_count, const std::vector<lmnt_value>& constants, const std::vector<lmnt_instruction>& function)
+static std::vector<char> create_archive(const char* def_name, uint16_t args_count, uint16_t rvals_count, uint16_t stack_count, const std::vector<lmnt_value>& constants, const std::vector<lmnt_instruction>& function, const lmnt_def_flags flags)
 {
     const size_t name_len = strlen(def_name);
     const size_t name_len_padded = LMNT_ROUND_UP(0x02 + name_len + 1, 4) - 2;
@@ -102,7 +102,7 @@ static std::vector<char> create_archive(const char* def_name, uint16_t args_coun
 
     const char def[] = {
         0x00, 0x00,                                    // defs[0].name
-        0x00, 0x00,                                    // defs[0].flags
+        flags & 0xFF, (flags >> 8) & 0xFF,             // defs[0].flags
         0x00, 0x00, 0x00, 0x00,                        // defs[0].code
         stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_unaligned
         stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_aligned
@@ -233,7 +233,7 @@ int main(int argc, char** argv)
     printf("Inputs: %zu, outputs: %zu, locals: %zu\n", lmnt_output.inputs_count, lmnt_output.outputs_count, lmnt_output.local_stack_count);
 
     {
-        auto lmnt_archive_data = create_archive("evaluate", uint16_t(args.size()), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions);
+        auto lmnt_archive_data = create_archive("evaluate", uint16_t(args.size()), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions, lmnt_output.flags);
 
         std::vector<char> lmnt_stack(32768);
         lmnt_ictx lctx;


### PR DESCRIPTION
This new flag allows consumers of archives to determine whether a given function includes backward-facing branches, and therefore is not guaranteed to halt. The flag is set at archive generation time and must be accurate for the archive to be valid.

LMNT changes:

- Removes defunct def flag `LMNT_DEFFLAG_LAMBDA`
- Adds new def flag `LMNT_DEFFLAG_HAS_BACKBRANCHES`
- Adds validation logic to check the accuracy of the backbranches flag
- Adds validation logic to consider a function invalid if an instruction branches (conditionally or unconditionally) to itself
- Adds tests to check validation behaviour
- Fixes pre-existing incorrect bitwise validation check

libelement changes:

- Adds support for compilation stage setting def flags
- Sets backbranches flag if `for` instruction is compiled
- Passes def flags out as part of compiled function for inclusion into the resulting archive