### PR TITLE
LMNT: fix check for using sincos

### DIFF
--- a/LMNT/include/lmnt/config.h
+++ b/LMNT/include/lmnt/config.h
@@ -41,6 +41,11 @@ extern "C" {
 #define LMNT_PRINTF printf
 #endif
 
+// sincosf function available on the target system
+// this function should be available in <math.h>
+// if left undefined, falls back to separate calls to sinf and cosf
+// LMNT_SINCOSF sincosf
+
 // Prints every instruction evaluated
 // This is, unsurprisingly, VERY spammy
 // #define LMNT_DEBUG_PRINT_EVALUATED_INSTRUCTIONS

--- a/LMNT/src/interpreter.c
+++ b/LMNT/src/interpreter.c
@@ -136,7 +136,7 @@ LMNT_ATTR_FAST static lmnt_result execute(lmnt_ictx* ctx, lmnt_value* rvals, con
         return LMNT_ERROR_RVALS_MISMATCH;
 
     lmnt_result opresult = LMNT_OK;
-    if ((def->flags & LMNT_DEFFLAG_EXTERN) == 0)
+    if (LMNT_LIKELY(!(def->flags & LMNT_DEFFLAG_EXTERN)))
     {
         // Get code
         const lmnt_code* defcode = validated_get_code(&ctx->archive, def->code);

--- a/LMNT/src/ops_trig.c
+++ b/LMNT/src/ops_trig.c
@@ -1,6 +1,10 @@
-#if defined(__GNUC__)
-    #define _GNU_SOURCE
-    #define USE_GNU_SINCOS
+#if defined(_GNU_SOURCE)
+    #include <features.h>
+    #if defined(__GLIBC__)
+        #define SINCOSF_FUNCTION sincosf
+    #elif defined(__APPLE__)
+        #define SINCOSF_FUNCTION __sincosf
+    #endif // else undefined
 #endif
 #include "lmnt/ops_trig.h"
 #include <math.h>
@@ -49,8 +53,8 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_atan2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_sincos(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-#if defined(USE_GNU_SINCOS)
-    sincosf(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
+#if defined(SINCOSF_FUNCTION)
+    SINCOSF_FUNCTION(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
 #else
     ctx->stack[arg2] = sinf(ctx->stack[arg1]);
     ctx->stack[arg3] = cosf(ctx->stack[arg1]);

--- a/LMNT/src/ops_trig.c
+++ b/LMNT/src/ops_trig.c
@@ -1,11 +1,4 @@
-#if defined(_GNU_SOURCE)
-    #include <features.h>
-    #if defined(__GLIBC__)
-        #define SINCOSF_FUNCTION sincosf
-    #elif defined(__APPLE__)
-        #define SINCOSF_FUNCTION __sincosf
-    #endif // else undefined
-#endif
+#include "lmnt/config.h"
 #include "lmnt/ops_trig.h"
 #include <math.h>
 
@@ -53,8 +46,8 @@ LMNT_ATTR_FAST lmnt_result lmnt_op_atan2(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_
 
 LMNT_ATTR_FAST lmnt_result lmnt_op_sincos(lmnt_ictx* ctx, lmnt_offset arg1, lmnt_offset arg2, lmnt_offset arg3)
 {
-#if defined(SINCOSF_FUNCTION)
-    SINCOSF_FUNCTION(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
+#if defined(LMNT_SINCOSF)
+    LMNT_SINCOSF(ctx->stack[arg1], &(ctx->stack[arg2]), &(ctx->stack[arg3]));
 #else
     ctx->stack[arg2] = sinf(ctx->stack[arg1]);
     ctx->stack[arg3] = cosf(ctx->stack[arg1]);

--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -340,10 +340,10 @@ namespace libelement::cli
                 0x00, 0x00,                                    // defs[0].name
                 0x00, 0x00,                                    // defs[0].flags
                 0x00, 0x00, 0x00, 0x00,                        // defs[0].code
-                stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_unaligned
-                stack_count & 0xFF, (stack_count >> 8) & 0xFF, // defs[0].stack_count_aligned
-                args_count & 0xFF, (args_count >> 8) & 0xFF,   // defs[0].args_count
-                rvals_count & 0xFF, (rvals_count >> 8) & 0xFF, // defs[0].rvals_count
+                char(stack_count & 0xFF), char((stack_count >> 8) & 0xFF), // defs[0].stack_count_unaligned
+                char(stack_count & 0xFF), char((stack_count >> 8) & 0xFF), // defs[0].stack_count_aligned
+                char(args_count & 0xFF), char((args_count >> 8) & 0xFF),   // defs[0].args_count
+                char(rvals_count & 0xFF), char((rvals_count >> 8) & 0xFF), // defs[0].rvals_count
             };
             memcpy(buf.data() + idx, def, sizeof(def));
             idx += sizeof(def);

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -11,7 +11,7 @@
 
 // create an allocation for this instruction and its dependents
 // must know what size the allocation is
-element_result create_virtual_result(
+static element_result create_virtual_result(
     compiler_state& state,
     const element::instruction* expr,
     stack_allocation** result = nullptr);
@@ -19,19 +19,19 @@ element_result create_virtual_result(
 // determine relationships between this instruction and its dependents
 // pinned and parenting statuses get set here
 // also take note of which instructions use data from other instructions
-element_result prepare_virtual_result(
+static element_result prepare_virtual_result(
     compiler_state& state,
     const element::instruction* expr,
     stack_allocation** result = nullptr);
 
 // decide how stack space is allocated for this instruction and its dependents
-element_result allocate_virtual_result(
+static element_result allocate_virtual_result(
     compiler_state& state,
     const element::instruction* expr,
     stack_allocation** result = nullptr);
 
 // generate LMNT bytecode for instruction and its dependents
-element_result compile_instruction(
+static element_result compile_instruction(
     compiler_state& state,
     const element::instruction* expr,
     std::vector<lmnt_instruction>& output);


### PR DESCRIPTION
We use `sincosf` where available, but this is shipped under different names by glibc and others (e.g. macOS's BSD-derived libc).

This PR updates our behaviour so that `sincosf` is purely opt-in via a config.h definition, as well as fixing a couple of other build issues.