### PR TITLE
LMNT: start of JIT interrupt support, other small adjustments

### DIFF
--- a/LMNT/include/lmnt/config.h
+++ b/LMNT/include/lmnt/config.h
@@ -44,7 +44,12 @@ extern "C" {
 // sincosf function available on the target system
 // this function should be available in <math.h>
 // if left undefined, falls back to separate calls to sinf and cosf
-// LMNT_SINCOSF sincosf
+// #define LMNT_SINCOSF sincosf
+
+// Defines whether to allow entries in the constants section of the stack to be modified
+// This was intended to be used to add persistent state between execution runs
+// However, current versions of Element/LMNT do not make use of it
+// #define LMNT_ALLOW_MODIFYING_STACK_CONSTANTS
 
 // Prints every instruction evaluated
 // This is, unsurprisingly, VERY spammy

--- a/LMNT/include/lmnt/jit.h
+++ b/LMNT/include/lmnt/jit.h
@@ -19,6 +19,7 @@ typedef struct
     lmnt_jit_fn function;
     void* buffer;
     size_t codesize;
+    void* interrupt;
 } lmnt_jit_fn_data;
 
 typedef struct

--- a/LMNT/include/lmnt/jit.h
+++ b/LMNT/include/lmnt/jit.h
@@ -15,6 +15,7 @@ typedef lmnt_result(*lmnt_jit_fn)(lmnt_ictx* ctx);
 
 typedef struct
 {
+    const lmnt_def* def;
     lmnt_jit_fn function;
     void* buffer;
     size_t codesize;
@@ -46,9 +47,8 @@ lmnt_result lmnt_jit_compile_with_stats(lmnt_ictx* ctx, const lmnt_def* def, lmn
 lmnt_result lmnt_jit_delete_function(lmnt_jit_fn_data* fndata);
 
 LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
-    lmnt_ictx* ctx, const lmnt_def* def, const lmnt_jit_fn_data* fndata,
+    lmnt_ictx* ctx, const lmnt_jit_fn_data* fndata,
     lmnt_value* rvals, const lmnt_offset rvals_count);
-
 
 #ifdef __cplusplus
 }

--- a/LMNT/include/lmnt/jit.h
+++ b/LMNT/include/lmnt/jit.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -20,6 +21,8 @@ typedef struct
     void* buffer;
     size_t codesize;
     void* interrupt;
+    void* interruptible_start;
+    void* interruptible_end;
 } lmnt_jit_fn_data;
 
 typedef struct
@@ -50,6 +53,8 @@ lmnt_result lmnt_jit_delete_function(lmnt_jit_fn_data* fndata);
 LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
     lmnt_ictx* ctx, const lmnt_jit_fn_data* fndata,
     lmnt_value* rvals, const lmnt_offset rvals_count);
+
+bool lmnt_jit_is_interruptible(const lmnt_jit_fn_data* fndata, void* inst_pointer);
 
 #ifdef __cplusplus
 }

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -398,6 +398,7 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | .code
     | ->lmnt_main:
     | prologue, use_nv
+    | ->exec_start:
 
     // store LMNT stack base
     const size_t ctx_stack_offset = offsetof(lmnt_ictx, stack);
@@ -1406,8 +1407,10 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         result = targetLinkAndEncode(&state->dasm_state, &fndata->buffer, &fndata->codesize);
         if (result == LMNT_OK) {
             // + 1 to indicate the function is THUMB not ARM
-            fndata->function = (lmnt_jit_fn)((intptr_t)labels[lbl_lmnt_main] + 1);
-            fndata->interrupt = (void*)((intptr_t)labels[lbl_lmnt_interrupt] + 1);
+            fndata->function = (lmnt_jit_fn)((uintptr_t)labels[lbl_lmnt_main] + 1);
+            fndata->interrupt = (void*)((uintptr_t)labels[lbl_lmnt_interrupt] + 1);
+            fndata->interruptible_start = (void*)((uintptr_t)labels[lbl_exec_start] + 1);
+            fndata->interruptible_end = (void*)((uintptr_t)labels[lbl_return] + 1);
         }
     }
     dasm_free(&state->dasm_state);

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -1386,7 +1386,9 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     // Ensure our return values or any updated constants are flushed to stack
     const lmnt_offset constants_count = validated_get_constants_count(&ctx->archive);
     const lmnt_offset rvals_start = constants_count + def->args_count;
+#if defined(LMNT_ALLOW_MODIFYING_STACK_CONSTANTS)
     platformWriteAndEvictByStack(state, 0, constants_count);
+#endif
     platformWriteAndEvictByStack(state, rvals_start, rvals_start + def->rvals_count);
     | mov r0, #LMNT_OK
     | ->return:

--- a/LMNT/src/jit/jit-armv7m.dasc
+++ b/LMNT/src/jit/jit-armv7m.dasc
@@ -1395,12 +1395,17 @@ lmnt_result lmnt_jit_armv7m_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     // can't use a negative immediate with mov
     | mvn r0, #((-LMNT_ERROR_ACCESS_VIOLATION) - 1)
     | b ->return
+    | -> lmnt_interrupt:
+    | mvn r0, #((-LMNT_INTERRUPTED) - 1)
+    | b -> return
 
     if (result == LMNT_OK) {
+        fndata->def = def;
         result = targetLinkAndEncode(&state->dasm_state, &fndata->buffer, &fndata->codesize);
         if (result == LMNT_OK) {
             // + 1 to indicate the function is THUMB not ARM
             fndata->function = (lmnt_jit_fn)((intptr_t)labels[lbl_lmnt_main] + 1);
+            fndata->interrupt = (void*)((intptr_t)labels[lbl_lmnt_interrupt] + 1);
         }
     }
     dasm_free(&state->dasm_state);

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -1370,7 +1370,9 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     // Ensure our return values or any updated constants are flushed to stack
     const lmnt_offset constants_count = validated_get_constants_count(&ctx->archive);
     const lmnt_offset rvals_start = constants_count + def->args_count;
+#if defined(LMNT_ALLOW_MODIFYING_STACK_CONSTANTS)
     platformWriteAndEvictByStack(state, 0, constants_count);
+#endif
     platformWriteAndEvictByStack(state, rvals_start, rvals_start + def->rvals_count);
     | mov rax, LMNT_OK
     | ->return:

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -1378,11 +1378,16 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | ->invalid_access:
     | mov rax, LMNT_ERROR_ACCESS_VIOLATION
     | jmp ->return
+    | ->lmnt_interrupt:
+    | mov rax, LMNT_INTERRUPTED
+    | jmp ->return
 
     if (result == LMNT_OK) {
+        fndata->def = def;
         result = targetLinkAndEncode(&state->dasm_state, &fndata->buffer, &fndata->codesize);
         if (result == LMNT_OK) {
             fndata->function = (lmnt_jit_fn)labels[lbl_lmnt_main];
+            fndata->interrupt = labels[lbl_lmnt_interrupt];
         }
     }
     dasm_free(&state->dasm_state);

--- a/LMNT/src/jit/jit-x86_64.dasc
+++ b/LMNT/src/jit/jit-x86_64.dasc
@@ -344,6 +344,7 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
     | .code
     | ->lmnt_main:
     | prologue, use_nv
+    | ->exec_start:
 
     // store LMNT stack base
     const size_t ctx_stack_offset = offsetof(lmnt_ictx, stack);
@@ -1390,6 +1391,8 @@ lmnt_result lmnt_jit_x86_64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_ji
         if (result == LMNT_OK) {
             fndata->function = (lmnt_jit_fn)labels[lbl_lmnt_main];
             fndata->interrupt = labels[lbl_lmnt_interrupt];
+            fndata->interruptible_start = labels[lbl_exec_start];
+            fndata->interruptible_end = labels[lbl_return];
         }
     }
     dasm_free(&state->dasm_state);

--- a/LMNT/src/jit/jit.c
+++ b/LMNT/src/jit/jit.c
@@ -22,12 +22,13 @@ lmnt_result lmnt_jit_arm64_compile(lmnt_ictx* ctx, const lmnt_def* def, lmnt_jit
 
 
 LMNT_ATTR_FAST lmnt_result lmnt_jit_execute(
-    lmnt_ictx* ctx, const lmnt_def* def, const lmnt_jit_fn_data* fndata,
+    lmnt_ictx* ctx, const lmnt_jit_fn_data* fndata,
     lmnt_value* rvals, const lmnt_offset rvals_count)
 {
     assert(ctx && ctx->archive.data);
     assert(ctx->stack && ctx->stack_count);
 
+    const lmnt_def* const def = fndata->def;
     ctx->cur_def = def;
     ctx->cur_instr = (lmnt_loffset)-1;
     lmnt_offset consts_count = validated_get_constants_count(&ctx->archive);

--- a/LMNT/src/jit/jit.c
+++ b/LMNT/src/jit/jit.c
@@ -121,3 +121,11 @@ lmnt_result lmnt_jit_delete_function(lmnt_jit_fn_data* fndata)
     LMNT_JIT_FREE_CFN_MEMORY(fndata->buffer, fndata->codesize);
     return LMNT_OK;
 }
+
+bool lmnt_jit_is_interruptible(const lmnt_jit_fn_data* fndata, void* inst_pointer)
+{
+    if (!fndata) return false;
+    return (
+        (uintptr_t)fndata->interruptible_start <= (uintptr_t)inst_pointer
+        && (uintptr_t)inst_pointer <= (uintptr_t)fndata->interruptible_end);
+}

--- a/LMNT/src/validation.c
+++ b/LMNT/src/validation.c
@@ -88,10 +88,13 @@ static inline lmnt_validation_result validate_operand_stack_read(const lmnt_arch
 
 static inline lmnt_validation_result validate_operand_stack_write(const lmnt_archive* archive, const lmnt_def* def, lmnt_offset arg, lmnt_offset count, size_t constants_count, size_t rw_stack_count)
 {
-    // Old: ensure we're not writing to a constant
-    // return (arg >= constants_count && arg + count <= constants_count + rw_stack_count) ? LMNT_VALIDATION_OK : LMNT_VERROR_ACCESS_VIOLATION;
-    // New: allow this since this space also now includes persisted variables
+#if defined(LMNT_ALLOW_MODIFYING_STACK_CONSTANTS)
+    // Allow writing to constants as this space also now includes persisted variables
     return (arg + count <= constants_count + rw_stack_count) ? LMNT_VALIDATION_OK : LMNT_VERROR_ACCESS_VIOLATION;
+#else
+    // Ensure we're not writing to anything in the constants part of the stack
+    return (arg >= constants_count && arg + count <= constants_count + rw_stack_count) ? LMNT_VALIDATION_OK : LMNT_VERROR_ACCESS_VIOLATION;
+#endif
 }
 
 static inline lmnt_validation_result validate_operand_immediate32(const lmnt_archive* archive, const lmnt_def* def, lmnt_offset arglo, lmnt_offset arghi, size_t constants_count, size_t rw_stack_count)

--- a/LMNT/test/testsetup_jit_native.h
+++ b/LMNT/test/testsetup_jit_native.h
@@ -45,7 +45,7 @@
 
 #undef  TEST_EXECUTE
 #define TEST_EXECUTE(ctx, fndata, rvals, rvals_count) \
-    lmnt_jit_execute(ctx, (fndata).def, (lmnt_jit_fn_data*)((fndata).data), (rvals), (lmnt_offset)(rvals_count))
+    lmnt_jit_execute(ctx, (lmnt_jit_fn_data*)((fndata).data), (rvals), (lmnt_offset)(rvals_count))
 
 CU_TEST_SETUP()
 {

--- a/LMNT/testapp/main.c
+++ b/LMNT/testapp/main.c
@@ -224,7 +224,7 @@ int main(int argc, char** argv)
         lmnt_update_args(&ctx, def, 0, c_args, sizeof(c_args) / sizeof(lmnt_value));
 
         // lmnt_result er = lmnt_execute(&ctx, def, c_rvals, sizeof(c_rvals)/sizeof(lmnt_value));
-        // lmnt_result er = lmnt_jit_execute(&ctx, def, fn, c_rvals, sizeof(c_rvals) / sizeof(lmnt_value));
+        // lmnt_result er = lmnt_jit_execute(&ctx, fn, c_rvals, sizeof(c_rvals) / sizeof(lmnt_value));
         // lmnt_result er = hardcoded_circle_ht(ctx.writable_stack, sizeof(c_args) / sizeof(lmnt_value), c_rvals, sizeof(c_rvals) / sizeof(lmnt_value));
         // assert(er >= THE_TEST_RVALS_SIZE);
         // position = [c_rvals[0], c_rvals[1], c_rvals[2]]
@@ -254,7 +254,7 @@ int main(int argc, char** argv)
             t1 = get_current_usec();
             for (size_t i = 0; i < itercount; ++i)
             {
-                lmnt_result er = lmnt_jit_execute(&ctx, def, &fndata, c_rvals, sizeof(c_rvals) / sizeof(lmnt_value));
+                lmnt_result er = lmnt_jit_execute(&ctx, &fndata, c_rvals, sizeof(c_rvals) / sizeof(lmnt_value));
                 assert(er >= THE_TEST_RVALS_SIZE);
                 c_args[0] += 1.0f / 10000.0f;
                 lmnt_update_args(&ctx, def, 0, c_args, sizeof(c_args) / sizeof(lmnt_value));

--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -432,7 +432,7 @@ private:
 
                 loperation = "jit execute";
                 lmnt_results.resize(output.count);
-                lresult = lmnt_jit_execute(&lctx, def, &fndata, lmnt_results.data(), lmnt_offset(lmnt_results.size()));
+                lresult = lmnt_jit_execute(&lctx, &fndata, lmnt_results.data(), lmnt_offset(lmnt_results.size()));
                 if (lresult != lmnt_results.size())
                     goto lmnt_error;
 


### PR DESCRIPTION
- Changes `lmnt_jit_fn_data` to also contain the pointer to the `lmnt_def` it was compiled from
- Removes `const lmnt_def*` parameters from JIT functions that take an `fn_data` since they're now redundant
- Changes `lmnt_jit_fn_data` to also contain a pointer to code which can be used to interrupt execution, as well as pointers to help determine whether it's safe to do so
- Adds `lmnt_jit_is_interruptible(fndata, void*)` to decide whether it's safe to interrupt a running JIT function
- Changes the "should stack constants be modifiable by LMNT instructions" question to be a config #define