### PR TITLE
LMNT: small tweaks

### DIFF
--- a/LMNT/src/validation.c
+++ b/LMNT/src/validation.c
@@ -48,9 +48,12 @@ static int32_t validate_def_with_flags(const lmnt_archive* archive, lmnt_offset 
     if (dhdr->stack_count > rw_stack_count)
         return LMNT_VERROR_STACK_SIZE;
 
+    const lmnt_offset inouts_count = dhdr->args_count + dhdr->rvals_count;
+    // Check the stack count vs args/rvals makes sense
+    if (dhdr->stack_count < inouts_count)
+        return LMNT_VERROR_DEF_HEADER;
     // If interface/extern, check we have zero locals
-    const lmnt_offset computed_stack_count = dhdr->args_count + dhdr->rvals_count;
-    if ((dhdr->flags & (LMNT_DEFFLAG_EXTERN | LMNT_DEFFLAG_INTERFACE)) != 0 && dhdr->stack_count != computed_stack_count)
+    if ((dhdr->flags & (LMNT_DEFFLAG_EXTERN | LMNT_DEFFLAG_INTERFACE)) != 0 && dhdr->stack_count != inouts_count)
         return LMNT_VERROR_DEF_HEADER;
 
     // Check we have the required flags specified

--- a/LMNT/testapp/circle.h
+++ b/LMNT/testapp/circle.h
@@ -7,7 +7,7 @@ static const char filedata_circle[] = {
     0x00, 0x00, 0x00, 0x00,
     0x0C, 0x00, 0x00, 0x00, // strings length
     0x10, 0x00, 0x00, 0x00, // defs length
-    0x44, 0x00, 0x00, 0x00, // code length
+    0x54, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'C', 'i', 'r', 'c', 'l', 'e', '\0', 0x00, 0x00, 0x00, // strings[0]
@@ -19,12 +19,14 @@ static const char filedata_circle[] = {
     0x04, 0x00, // defs[0].rvals_count
     0x00, 0x00, // defs[0].default_args_index
     // code
-    0x08, 0x00, 0x00, 0x00, // ops_count
-    // stack: [tau, 1.0 | t, i, radius, interval | pos_x, pos_y, pos_z, intens]
-    //temp7 = t / interval
-    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x02, 0x05, 0x07),
-    //temp7 = mod(temp7, 1)
-    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x01, 0x07),
+    0x0A, 0x00, 0x00, 0x00, // ops_count
+    // stack: [tau, 1.0 | time_i, time_f, radius, interval | pos_x, pos_y, pos_z, intens]
+    //temp7 = ((time_i % interval) + time_f) % interval
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x02, 0x05, 0x07),
+    LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x07, 0x03, 0x07),
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x05, 0x07),
+    //temp7 = div(temp7, interval)
+    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x07, 0x05, 0x07),
     //temp7 = mul(temp7, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x00, 0x07),
     //pos_x = cos(temp7), pos_y = sin(temp7)

--- a/LMNT/testapp/circle.h
+++ b/LMNT/testapp/circle.h
@@ -7,7 +7,7 @@ static const char filedata_circle[] = {
     0x00, 0x00, 0x00, 0x00,
     0x0C, 0x00, 0x00, 0x00, // strings length
     0x10, 0x00, 0x00, 0x00, // defs length
-    0x4C, 0x00, 0x00, 0x00, // code length
+    0x44, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'C', 'i', 'r', 'c', 'l', 'e', '\0', 0x00, 0x00, 0x00, // strings[0]
@@ -19,7 +19,7 @@ static const char filedata_circle[] = {
     0x04, 0x00, // defs[0].rvals_count
     0x00, 0x00, // defs[0].default_args_index
     // code
-    0x09, 0x00, 0x00, 0x00, // ops_count
+    0x08, 0x00, 0x00, 0x00, // ops_count
     // stack: [tau, 1.0 | t, i, radius, interval | pos_x, pos_y, pos_z, intens]
     //temp7 = t / interval
     LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x02, 0x05, 0x07),
@@ -27,12 +27,10 @@ static const char filedata_circle[] = {
     LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x01, 0x07),
     //temp7 = mul(temp7, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x00, 0x07),
-    //pos_x = cos(temp7)
-    LMNT_OP_BYTES(LMNT_OP_COS, 0x07, 0x00, 0x06),
+    //pos_x = cos(temp7), pos_y = sin(temp7)
+    LMNT_OP_BYTES(LMNT_OP_SINCOS, 0x07, 0x06, 0x07),
     //pos_x = mul(pos_x, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x06, 0x04, 0x06),
-    //pos_y = sin(temp7)
-    LMNT_OP_BYTES(LMNT_OP_SIN, 0x07, 0x00, 0x07),
     //pos_y = mul(pos_y, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x04, 0x07),
     //stack[8] = 0.15

--- a/LMNT/testapp/circle_double.h
+++ b/LMNT/testapp/circle_double.h
@@ -5,7 +5,7 @@ static const char filedata_circle_double[] = {
     0x00, 0x00, 0x00, 0x00,
     0x18, 0x00, 0x00, 0x00, // strings length
     0x20, 0x00, 0x00, 0x00, // defs length
-    0x54, 0x00, 0x00, 0x00, // code length
+    0x64, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'd', 'o', 'u', 'b', 'l', 'e', '\0', 0x00, 0x00, 0x00, // strings[0]
@@ -25,12 +25,14 @@ static const char filedata_circle_double[] = {
     0x04, 0x00, // defs[1].rvals_count
     0x00, 0x00, // defs[1].default_args_index
     // code
-    0x0A, 0x00, 0x00, 0x00, // ops_count
+    0x0C, 0x00, 0x00, 0x00, // ops_count
     // stack: [tau, 1.0 | t, i, radius, interval | pos_x, pos_y, pos_z, intens]
-    //temp7 = t / interval
-    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x02, 0x05, 0x07),
-    //temp7 = mod(temp7, 1)
-    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x01, 0x07),
+    //temp7 = ((time_i % interval) + time_f) % interval
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x02, 0x05, 0x07),
+    LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x07, 0x03, 0x07),
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x05, 0x07),
+    //temp7 = div(temp7, interval)
+    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x07, 0x05, 0x07),
     //temp7 = mul(temp7, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x00, 0x07),
     //pos_x = cos(temp7), pos_y = sin(temp7)

--- a/LMNT/testapp/circle_double.h
+++ b/LMNT/testapp/circle_double.h
@@ -5,7 +5,7 @@ static const char filedata_circle_double[] = {
     0x00, 0x00, 0x00, 0x00,
     0x18, 0x00, 0x00, 0x00, // strings length
     0x20, 0x00, 0x00, 0x00, // defs length
-    0x5C, 0x00, 0x00, 0x00, // code length
+    0x54, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'd', 'o', 'u', 'b', 'l', 'e', '\0', 0x00, 0x00, 0x00, // strings[0]
@@ -25,7 +25,7 @@ static const char filedata_circle_double[] = {
     0x04, 0x00, // defs[1].rvals_count
     0x00, 0x00, // defs[1].default_args_index
     // code
-    0x0B, 0x00, 0x00, 0x00, // ops_count
+    0x0A, 0x00, 0x00, 0x00, // ops_count
     // stack: [tau, 1.0 | t, i, radius, interval | pos_x, pos_y, pos_z, intens]
     //temp7 = t / interval
     LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x02, 0x05, 0x07),
@@ -33,12 +33,10 @@ static const char filedata_circle_double[] = {
     LMNT_OP_BYTES(LMNT_OP_MODSS, 0x07, 0x01, 0x07),
     //temp7 = mul(temp7, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x00, 0x07),
-    //pos_x = cos(temp7)
-    LMNT_OP_BYTES(LMNT_OP_COS, 0x07, 0x00, 0x06),
+    //pos_x = cos(temp7), pos_y = sin(temp7)
+    LMNT_OP_BYTES(LMNT_OP_SINCOS, 0x07, 0x06, 0x07),
     //pos_x = mul(pos_x, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x06, 0x04, 0x06),
-    //pos_y = sin(temp7)
-    LMNT_OP_BYTES(LMNT_OP_SIN, 0x07, 0x00, 0x07),
     //pos_y = mul(pos_y, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x07, 0x04, 0x07),
     //stack[8] = 0.15

--- a/LMNT/testapp/circle_ht.h
+++ b/LMNT/testapp/circle_ht.h
@@ -7,7 +7,7 @@ static const char filedata_circle_ht[] = {
     0x00, 0x00, 0x00, 0x00,
     0x0C, 0x00, 0x00, 0x00, // strings length
     0x10, 0x00, 0x00, 0x00, // defs length
-    0x9C, 0x00, 0x00, 0x00, // code length
+    0xAC, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'C', 'i', 'r', 'c', 'l', 'e', 'H', 'T', '\0', 0x00, // strings[0]
@@ -19,17 +19,19 @@ static const char filedata_circle_ht[] = {
     0x04, 0x00, // defs[0].rvals_count
     0x00, 0x00, // defs[0].default_args_index
     // code
-    0x13, 0x00, 0x00, 0x00, // ops_count
+    0x15, 0x00, 0x00, 0x00, // ops_count
     // stack: [
     // 0x00 | tau, 1.0
-    // 0x02 | t, i, radius, interval, t11, t12, t13, t14, t21, t22, t23, t24, t31, t32, t33, t34
+    // 0x02 | time_i, time_f, radius, interval, t11, t12, t13, t14, t21, t22, t23, t24, t31, t32, t33, t34
     // 0x12 | pos_x, pos_y, pos_z, intens
     // 0x16 | temp22, temp23, temp24, temp25, temp26
     // ]
-    //temp22 = t / interval
-    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x02, 0x05, 0x16),
-    //temp22 = mod(temp22, 1)
-    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x16, 0x01, 0x16),
+    //temp22 = ((time_i % interval) + time_f) % interval
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x02, 0x05, 0x16),
+    LMNT_OP_BYTES(LMNT_OP_ADDSS, 0x16, 0x03, 0x16),
+    LMNT_OP_BYTES(LMNT_OP_MODSS, 0x16, 0x05, 0x16),
+    //temp22 = div(temp22, interval)
+    LMNT_OP_BYTES(LMNT_OP_DIVSS, 0x16, 0x05, 0x16),
     //temp22 = mul(temp22, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x16, 0x00, 0x16),
     //pos_x = cos(temp22), pos_y = sin(temp22)

--- a/LMNT/testapp/circle_ht.h
+++ b/LMNT/testapp/circle_ht.h
@@ -7,7 +7,7 @@ static const char filedata_circle_ht[] = {
     0x00, 0x00, 0x00, 0x00,
     0x0C, 0x00, 0x00, 0x00, // strings length
     0x10, 0x00, 0x00, 0x00, // defs length
-    0xA4, 0x00, 0x00, 0x00, // code length
+    0x9C, 0x00, 0x00, 0x00, // code length
     0x04, 0x00, 0x00, 0x00, // data length
     0x08, 0x00, 0x00, 0x00, // constants_length
     0x0A, 0x00, 'C', 'i', 'r', 'c', 'l', 'e', 'H', 'T', '\0', 0x00, // strings[0]
@@ -19,7 +19,7 @@ static const char filedata_circle_ht[] = {
     0x04, 0x00, // defs[0].rvals_count
     0x00, 0x00, // defs[0].default_args_index
     // code
-    0x14, 0x00, 0x00, 0x00, // ops_count
+    0x13, 0x00, 0x00, 0x00, // ops_count
     // stack: [
     // 0x00 | tau, 1.0
     // 0x02 | t, i, radius, interval, t11, t12, t13, t14, t21, t22, t23, t24, t31, t32, t33, t34
@@ -32,12 +32,10 @@ static const char filedata_circle_ht[] = {
     LMNT_OP_BYTES(LMNT_OP_MODSS, 0x16, 0x01, 0x16),
     //temp22 = mul(temp22, tau)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x16, 0x00, 0x16),
-    //pos_x = cos(temp22)
-    LMNT_OP_BYTES(LMNT_OP_COS, 0x16, 0x00, 0x12),
+    //pos_x = cos(temp22), pos_y = sin(temp22)
+    LMNT_OP_BYTES(LMNT_OP_SINCOS, 0x16, 0x12, 0x13),
     //pos_x = mul(pos_x, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x12, 0x04, 0x12),
-    //pos_y = sin(temp22)
-    LMNT_OP_BYTES(LMNT_OP_SIN, 0x16, 0x00, 0x13),
     //pos_y = mul(pos_y, radius)
     LMNT_OP_BYTES(LMNT_OP_MULSS, 0x13, 0x04, 0x13),
     //pos_z = 0.00

--- a/LMNT/testapp/main.c
+++ b/LMNT/testapp/main.c
@@ -126,20 +126,22 @@ lmnt_result hardcoded_circle_ht(float* args, size_t args_count, float* rvals, si
 }
 
 
-/*
-int main(int argc, char** argv)
+static void print_archive_hex(const char* archive, size_t size, size_t width)
 {
-    float v = 0.15f;
-
-    printf("%02X %02X %02X %02X\n",
-        ((*(uint32_t*)&v) & 0xFF),
-        (((*(uint32_t*)&v) >> 8) & 0xFF),
-        (((*(uint32_t*)&v) >> 16) & 0xFF),
-        (((*(uint32_t*)&v) >> 24) & 0xFF));
-
-    return 0;
+    for (size_t i = 0; i < size / width; ++i) {
+        LMNT_PRINTF("%04zX  |  ", i*width);
+        for (size_t j = 0; j < width; ++j)
+            LMNT_PRINTF("%02X ", (unsigned char)archive[i*width + j]);
+        LMNT_PRINTF("\n");
+    }
+    if (size - (size/width)*width) {
+        LMNT_PRINTF("%04zX  |  ", (size/width)*width);
+        for (size_t j = 0; j < (size - (size/width)*width); ++j)
+            LMNT_PRINTF("%02X ", (unsigned char)archive[(size/width)*width + j]);
+        LMNT_PRINTF("\n");
+    }
 }
-*/
+
 
 #define THE_TEST filedata_circle_ht
 #define THE_TEST_NAME "circle_ht"
@@ -171,7 +173,7 @@ int main(int argc, char** argv)
         printf("VALIDATION FAILED: %u\n", lvr);
         return 1;
     }
-    
+
     const lmnt_def* def;
     lmnt_result dr = lmnt_find_def(&ctx, THE_TEST_DEF, &def);
     assert(dr == LMNT_OK);

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <vector>
 #include <unordered_map>
+#include <cmath>
 
 #define U16_LO(x) static_cast<uint16_t>((x)&0xFFFF)
 #define U16_HI(x) static_cast<uint16_t>(((x) >> 16) & 0xFFFF)
@@ -556,6 +557,9 @@ static element_result compile_binary(
                 return ELEMENT_OK;
             } else if (base_value == 10.0f) {
                 output.emplace_back(lmnt_instruction{ LMNT_OP_LOG10, arg1_stack_idx, 0, stack_idx });
+                return ELEMENT_OK;
+            } else if (base_value == std::exp(1.0f)) {
+                output.emplace_back(lmnt_instruction{ LMNT_OP_LN, arg1_stack_idx, 0, stack_idx });
                 return ELEMENT_OK;
             }
         }


### PR DESCRIPTION
**LMNT**
- Tightens validation of defs to ensure that `stack_count >= args_count + rvals_count`
- Changes testapp examples to use split two-part time (integer + fractional)
- Changes testapp examples to use combined `SINCOS` instruction where appropriate
- Adds function to testapp to print the archive in use as raw hex bytes

**libelement**
- LMNT compiler: add constant-base optimisation for `LN` (base `e`) along with the others recently added