### PR TITLE
LMNT: small dispatch optimisations

### DIFF
--- a/LMNT/include/lmnt/interpreter.h
+++ b/LMNT/include/lmnt/interpreter.h
@@ -21,7 +21,7 @@ enum
     LMNT_ISTATUS_CMP_GT = (1U << 2),       // greater than
     LMNT_ISTATUS_CMP_UN = (1U << 7),       // unordered (i.e. NaNs present)
 
-    LMNT_ISTATUS_INTERRUPTED = (1U << 31), // function is being interrupted (not used by all dispatch methods)
+    LMNT_ISTATUS_INTERRUPTED = (1U << 31), // function is being interrupted
 };
 
 // Main interpreter context struct
@@ -42,7 +42,6 @@ struct lmnt_ictx
     const lmnt_def* cur_def;
     lmnt_loffset cur_instr;
     size_t cur_stack_count;
-    const lmnt_op_fn* op_functions;
     uint32_t status_flags;
 };
 

--- a/LMNT/src/dispatch_computed_goto.h
+++ b/LMNT/src/dispatch_computed_goto.h
@@ -120,15 +120,13 @@ dispatch:
             // the context's instruction pointer has been updated, refresh
             instr = ctx->cur_instr - 1; // will be incremented momentarily
         } else {
-            if (opresult == LMNT_OK && (ctx->status_flags & LMNT_ISTATUS_INTERRUPTED))
-                opresult = LMNT_INTERRUPTED;
-            goto end;
+            goto endcheck;
         }
     }
 
 #define GENERATE_DISPATCHOK() \
-    if (++instr >= icount)\
-        goto end;\
+    if (++instr >= icount || (ctx->status_flags & LMNT_ISTATUS_INTERRUPTED))\
+        goto endcheck;\
     op = instructions[instr];\
     goto *jump_targets[op.opcode];
 
@@ -234,6 +232,9 @@ GENERATE_OP(extcall, dispatch);
 #undef GENERATE_OP_NOFAIL
 #undef GENERATE_OP
 
+endcheck:
+    if (opresult == LMNT_OK && (ctx->status_flags & LMNT_ISTATUS_INTERRUPTED))
+        opresult = LMNT_INTERRUPTED;
 end:
     ctx->cur_instr = instr;
     return opresult;


### PR DESCRIPTION
- Removes jump table's "special" interrupt mode where it swaps the jump table for an interrupt-only one
- Replaces it with the standard "check the status flags" method of interrupting, which is actually now faster
- Updates computed goto dispatch so it always respects the interrupt flag (costs ~3-4% perf in a quick test)