### PR TITLE
LMNT: added better CMake checks when choosing which JIT architectures to build

### DIFF
--- a/LMNT/CMakeLists.txt
+++ b/LMNT/CMakeLists.txt
@@ -9,7 +9,13 @@ include(DetectTargetArch)
 
 option(LMNT_BUILD_JIT "Build the DynASM-based JIT" ON)
 set(LMNT_JIT_ARCHITECTURES "NATIVE" CACHE STRING "List of architectures to build the JIT for")
-list(TRANSFORM LMNT_JIT_ARCHITECTURES REPLACE "NATIVE" "${LMNT_TARGET_ARCH}")
+# check if a JIT for the current native architecture exists
+# if so, set that arch as a JIT target if specified; if not, just remove native as a JIT target
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/jit/jit-${LMNT_TARGET_ARCH}.dasc")
+    list(TRANSFORM LMNT_JIT_ARCHITECTURES REPLACE "NATIVE" "${LMNT_TARGET_ARCH}")
+else ()
+    list(TRANSFORM LMNT_JIT_ARCHITECTURES REMOVE_ITEM "NATIVE")
+endif ()
 list(REMOVE_DUPLICATES LMNT_JIT_ARCHITECTURES)
 
 # Enable ASAN if requested

--- a/LMNT/src/jit/CMakeLists.txt
+++ b/LMNT/src/jit/CMakeLists.txt
@@ -33,6 +33,10 @@ foreach (arch IN LISTS LMNT_JIT_ARCHITECTURES)
     set(jit_input "${CMAKE_CURRENT_SOURCE_DIR}/jit-${arch_lower}.dasc")
     set(jit_output "${CMAKE_CURRENT_BINARY_DIR}/jit-${arch_lower}.c")
 
+    if (NOT EXISTS "${jit_input}")
+        message(FATAL_ERROR "There is no LMNT JIT implementation for specified architecture ${arch}!")
+    endif ()
+
     set (jit_flags "TARGET_${arch}" "HOST_${LMNT_TARGET_ARCH}")
     if (WIN32)
         list (APPEND jit_flags "TARGET_WIN" "HOST_WIN")


### PR DESCRIPTION
The main CMakeLists check should ensure that `NATIVE` is only transformed into the current native architecture _if_ there is a JIT implementation for that architecture; otherwise it's just removed.

The second check inside the JIT CMakeLists should ensure that when building the JIT is enabled and it's trying to build for a particular architecture (native or otherwise), a good error message is generated if that architecture doesn't have a JIT implementation.