### PR TITLE
libelement: add LMNT export functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,7 +86,7 @@ JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
+MaxEmptyLinesToKeep: 3
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: true

--- a/libelement.CLI/include/compile_command.hpp
+++ b/libelement.CLI/include/compile_command.hpp
@@ -106,7 +106,7 @@ public:
         auto response = generate_response(ELEMENT_ERROR_UNKNOWN, element_outputs{}, compilation_input.get_log_json());
 
         if (common_arguments.target == Target::LMNT || common_arguments.target == Target::LMNTJit)
-            response = compile_lmnt(compilation_input, compiled_function, inputs_size, outputs_size, custom_arguments.output_path);
+            response = compile_lmnt(compilation_input, compiled_function, custom_arguments.name, inputs_size, outputs_size, custom_arguments.output_path);
 
         element_instruction_delete(&compiled_function);
 
@@ -237,7 +237,7 @@ private:
         element_lmnt_compiled_function lmnt_output;
         std::vector<element_value> constants;
 
-        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, constants, inputs_size, lmnt_output);
+        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, custom_arguments.name, constants, inputs_size, lmnt_output);
         if (result != ELEMENT_OK) {
             printf("RUH ROH: %d\n", result);
             return generate_response(result, "failed to compile LMNT function", compilation_input.get_log_json());

--- a/libelement.CLI/include/compile_command.hpp
+++ b/libelement.CLI/include/compile_command.hpp
@@ -88,7 +88,7 @@ public:
         }
 
         size_t inputs_size = 0;
-        result = element_instruction_get_inputs_size(compiled_function, &inputs_size);
+        result = element_instruction_get_function_inputs_size(compiled_function, &inputs_size);
         if (result != ELEMENT_OK) {
             return compiler_message(error_conversion(result),
                 "Failed to get inputs size of: " + custom_arguments.name + " with element_result " + std::to_string(result),
@@ -229,6 +229,7 @@ private:
     compiler_message compile_lmnt(
         const compilation_input& compilation_input,
         element_instruction* instruction,
+        std::string name,
         size_t inputs_size,
         size_t outputs_size,
         std::string output_path) const
@@ -237,7 +238,7 @@ private:
         element_lmnt_compiled_function lmnt_output;
         std::vector<element_value> constants;
 
-        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, custom_arguments.name, constants, inputs_size, lmnt_output);
+        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, name, constants, inputs_size, lmnt_output);
         if (result != ELEMENT_OK) {
             printf("RUH ROH: %d\n", result);
             return generate_response(result, "failed to compile LMNT function", compilation_input.get_log_json());

--- a/libelement.CLI/include/declaration_command.hpp
+++ b/libelement.CLI/include/declaration_command.hpp
@@ -63,14 +63,14 @@ public:
         }
 
         size_t code_size = 0;
-        result = element_declaration_to_code(decl, custom_arguments.definition, nullptr, &code_size);
+        result = element_declaration_to_code(decl, true, custom_arguments.definition, nullptr, &code_size);
         if (result != ELEMENT_OK) {
             return compiler_message(error_conversion(result),
                 "Failed to convert declaration to code with element_result " + std::to_string(result),
                 compilation_input.get_log_json());
         }
         std::string code(code_size, '\0');
-        result = element_declaration_to_code(decl, custom_arguments.definition, code.data(), &code_size);
+        result = element_declaration_to_code(decl, true, custom_arguments.definition, code.data(), &code_size);
         if (result != ELEMENT_OK) {
             return compiler_message(error_conversion(result),
                 "Failed to convert declaration to code with element_result " + std::to_string(result),

--- a/libelement.CLI/include/evaluate_command.hpp
+++ b/libelement.CLI/include/evaluate_command.hpp
@@ -367,7 +367,7 @@ private:
         lmnt_validation_result lvresult = LMNT_VALIDATION_OK;
         const char* loperation = "nothing ecksdee";
 
-        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, constants, input.count, lmnt_output);
+        auto result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, "evaluate", constants, input.count, lmnt_output);
         if (result != ELEMENT_OK) {
             printf("RUH ROH: %d\n", result);
             goto cleanup;

--- a/libelement.CLI/include/parse_command.hpp
+++ b/libelement.CLI/include/parse_command.hpp
@@ -12,10 +12,10 @@ struct parse_command_arguments
     [[nodiscard]] std::string as_string() const
     {
         std::stringstream ss;
-        ss << "parse ";
+        ss << "parse";
 
         if (no_validation)
-            ss << "--no-validation ";
+            ss << " --no-validation";
 
         return ss.str();
     }
@@ -68,7 +68,7 @@ public:
 
         auto* const command = app.add_subcommand("parse")->fallthrough();
         command->add_flag("--no-validation", arguments->no_validation,
-            "Expression to evaluate.");
+            "Whether to validate the parsed code.");
 
         command->callback([callback, common_arguments, arguments]() {
             parse_command cmd(*common_arguments, *arguments);

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -230,7 +230,10 @@ if (ELEMENT_FORCE_FALLBACK_FS)
 endif()
 
 add_library(element ${element_sources})
-set_property(TARGET element PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(element PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_VISIBILITY_PRESET "hidden"
+    C_VISIBILITY_PRESET "hidden")
 target_compile_definitions(element PRIVATE "ELEMENT_EXPORT")
 # make sure we don't add dllimport if building statically
 if (NOT BUILD_SHARED_LIBS)

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -232,6 +232,10 @@ endif()
 add_library(element ${element_sources})
 set_property(TARGET element PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(element PRIVATE "ELEMENT_EXPORT")
+# make sure we don't add dllimport if building statically
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(element INTERFACE "ELEMENT_STATIC")
+endif ()
 add_library(element::element ALIAS element)
 
 # For VS

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -200,6 +200,7 @@ set(element_sources
     "src/lmnt/compiler.hpp"
     "src/lmnt/compiler_state.cpp"
     "src/lmnt/compiler_state.hpp"
+    "src/lmnt/exporter.cpp"
 
     #Util
     "src/stringutil.hpp"

--- a/libelement/CMakeLists.txt
+++ b/libelement/CMakeLists.txt
@@ -228,8 +228,9 @@ if (ELEMENT_FORCE_FALLBACK_FS)
     add_definitions(-DELEMENT_FORCE_FALLBACK_FS)
 endif()
 
-add_library(element STATIC ${element_sources})
+add_library(element ${element_sources})
 set_property(TARGET element PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(element PRIVATE "ELEMENT_EXPORT")
 add_library(element::element ALIAS element)
 
 # For VS

--- a/libelement/include/element/ast.h
+++ b/libelement/include/element/ast.h
@@ -60,7 +60,7 @@ typedef struct element_ast element_ast;
  *
  * @param[in,out] ast           ast node to be deleted, assigns nullptr on deletion
  */
-void element_ast_delete(
+ELEMENT_API void element_ast_delete(
     element_ast** ast);
 
 /**
@@ -71,7 +71,7 @@ void element_ast_delete(
  *
  * @return ELEMENT_OK success
  */
-element_result element_ast_get_flags(
+ELEMENT_API element_result element_ast_get_flags(
     const element_ast* ast,
     element_ast_flags* flags);
 
@@ -83,7 +83,7 @@ element_result element_ast_get_flags(
  *
  * @return ELEMENT_OK success
  */
-element_result element_ast_get_nearest_token(
+ELEMENT_API element_result element_ast_get_nearest_token(
     const element_ast* ast,
     const element_token** token);
 
@@ -95,7 +95,7 @@ element_result element_ast_get_nearest_token(
  *
  * @return ELEMENT_OK success
  */
-element_result element_ast_get_type(
+ELEMENT_API element_result element_ast_get_type(
     const element_ast* ast,
     element_ast_node_type* type);
 
@@ -110,7 +110,7 @@ element_result element_ast_get_type(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL value is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT value is not an identifier
  */
-element_result element_ast_get_value_as_identifier(
+ELEMENT_API element_result element_ast_get_value_as_identifier(
     const element_ast* ast,
     const char** value);
 
@@ -125,7 +125,7 @@ element_result element_ast_get_value_as_identifier(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL value pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT value is not a literal
  */
-element_result element_ast_get_value_as_literal(
+ELEMENT_API element_result element_ast_get_value_as_literal(
     const element_ast* ast,
     element_value* value);
 
@@ -139,7 +139,7 @@ element_result element_ast_get_value_as_literal(
  * @return ELEMENT_ERROR_API_AST_IS_NULL ast node pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL ast node has no parent
  */
-element_result element_ast_get_parent(
+ELEMENT_API element_result element_ast_get_parent(
     const element_ast* ast,
     element_ast** parent);
 
@@ -153,7 +153,7 @@ element_result element_ast_get_parent(
  * @return ELEMENT_ERROR_API_AST_IS_NULL ast node pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL count pointer is null
  */
-element_result element_ast_get_child_count(
+ELEMENT_API element_result element_ast_get_child_count(
     const element_ast* ast,
     size_t* count);
 
@@ -169,7 +169,7 @@ element_result element_ast_get_child_count(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL child pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT index exceeds child count
  */
-element_result element_ast_get_child(
+ELEMENT_API element_result element_ast_get_child(
     const element_ast* ast,
     size_t index,
     element_ast** child);
@@ -184,7 +184,7 @@ element_result element_ast_get_child(
  * @return ELEMENT_ERROR_API_AST_IS_NULL ast node pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL root node pointer is null
  */
-element_result element_ast_get_root(
+ELEMENT_API element_result element_ast_get_root(
     element_ast* ast,
     element_ast** root);
 
@@ -198,7 +198,7 @@ element_result element_ast_get_root(
  * @return ELEMENT_ERROR_API_AST_IS_NULL ast node pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL root node pointer is null
  */
-element_result element_ast_get_root_const(
+ELEMENT_API element_result element_ast_get_root_const(
     const element_ast* ast,
     const element_ast** root);
 
@@ -215,7 +215,7 @@ element_result element_ast_get_root_const(
  * @return ELEMENT_ERROR_API_INVALID_INPUT output_buffer pointer is null
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER result size exceeds output_buffer_size
  */
-element_result element_ast_to_string(
+ELEMENT_API element_result element_ast_to_string(
     const element_ast* ast,
     const element_ast* ast_to_mark,
     char* output_buffer,

--- a/libelement/include/element/common.h
+++ b/libelement/include/element/common.h
@@ -2,17 +2,25 @@
     #define ELEMENT_COMMON_H
 
     // shared library export attributes
-    #ifdef _WIN32
-        #ifdef ELEMENT_EXPORT
+    #if defined(_WIN32)
+        #if defined(ELEMENT_EXPORT)
             #define ELEMENT_API __declspec(dllexport)
+            #define ELEMENT_API_CLASS
+        #elif defined(ELEMENT_STATIC)
+            #define ELEMENT_API
             #define ELEMENT_API_CLASS
         #else
             #define ELEMENT_API __declspec(dllimport)
             #define ELEMENT_API_CLASS
         #endif
     #else
-        #define ELEMENT_API __attribute__((visibility("default")))
-        #define ELEMENT_API_CLASS __attribute__((visibility("default")))
+        #if defined(ELEMENT_EXPORT)
+            #define ELEMENT_API __attribute__((visibility("default")))
+            #define ELEMENT_API_CLASS __attribute__((visibility("default")))
+        #else
+            #define ELEMENT_API
+            #define ELEMENT_API_CLASS
+        #endif
     #endif
 
     #if defined(__cplusplus)

--- a/libelement/include/element/common.h
+++ b/libelement/include/element/common.h
@@ -1,6 +1,20 @@
 #if !defined(ELEMENT_COMMON_H)
     #define ELEMENT_COMMON_H
 
+    // shared library export attributes
+    #ifdef _WIN32
+        #ifdef ELEMENT_EXPORT
+            #define ELEMENT_API __declspec(dllexport)
+            #define ELEMENT_API_CLASS
+        #else
+            #define ELEMENT_API __declspec(dllimport)
+            #define ELEMENT_API_CLASS
+        #endif
+    #else
+        #define ELEMENT_API __attribute__((visibility("default")))
+        #define ELEMENT_API_CLASS __attribute__((visibility("default")))
+    #endif
+
     #if defined(__cplusplus)
 extern "C" {
     #endif

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -485,6 +485,7 @@ ELEMENT_API element_result element_interpreter_typeof_expression(
 ELEMENT_API element_result element_interpreter_export_lmnt(
     element_interpreter_ctx* context,
     const element_declaration** decls,
+    const char** funcnames,
     size_t decls_count,
     char* buffer,
     size_t* bufsize);

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -54,7 +54,7 @@ typedef struct element_interpreter_ctx element_interpreter_ctx;
  * @return ELEMENT_OK created an interpreter successfully
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL interpreter pointer is null
  */
-element_result element_interpreter_create(
+ELEMENT_API element_result element_interpreter_create(
     element_interpreter_ctx** interpreter);
 
 /**
@@ -62,7 +62,7 @@ element_result element_interpreter_create(
  *
  * @param[in,out] interpreter   interpreter context
  */
-void element_interpreter_delete(
+ELEMENT_API void element_interpreter_delete(
     element_interpreter_ctx** interpreter);
 
 /**
@@ -76,7 +76,7 @@ void element_interpreter_delete(
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter pointer is null
  * @return ELEMENT_ERROR_API_STRING_IS_NULL string and/or filename pointer is null
  */
-element_result element_interpreter_load_string(
+ELEMENT_API element_result element_interpreter_load_string(
     element_interpreter_ctx* interpreter,
     const char* string,
     const char* filename);
@@ -91,7 +91,7 @@ element_result element_interpreter_load_string(
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter is null
  * @return ELEMENT_ERROR_API_STRING_IS_NULL file name pointer is null
  */
-element_result element_interpreter_load_file(
+ELEMENT_API element_result element_interpreter_load_file(
     element_interpreter_ctx* interpreter,
     const char* file);
 
@@ -106,7 +106,7 @@ element_result element_interpreter_load_file(
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT file names pointer is null
  */
-element_result element_interpreter_load_files(
+ELEMENT_API element_result element_interpreter_load_files(
     element_interpreter_ctx* interpreter,
     const char** files,
     int files_count);
@@ -122,7 +122,7 @@ element_result element_interpreter_load_files(
  * @return ELEMENT_ERROR_API_STRING_IS_NULL package path pointer is null
  * @return ELEMENT_ERROR_DIRECTORY_NOT_FOUND directory not found
 */
-element_result element_interpreter_load_package(
+ELEMENT_API element_result element_interpreter_load_package(
     element_interpreter_ctx* interpreter,
     const char* package);
 
@@ -138,7 +138,7 @@ element_result element_interpreter_load_package(
  * @return ELEMENT_ERROR_API_INVALID_INPUT package paths pointer is null
  * @return ELEMENT_ERROR_DIRECTORY_NOT_FOUND directory not found
  */
-element_result element_interpreter_load_packages(
+ELEMENT_API element_result element_interpreter_load_packages(
     element_interpreter_ctx* interpreter,
     const char** packages,
     int packages_count);
@@ -153,7 +153,7 @@ element_result element_interpreter_load_packages(
  * @return ELEMENT_ERROR_PRELUDE_ALREADY_LOADED prelude already loaded
  * @return ELEMENT_ERROR_DIRECTORY_NOT_FOUND prelude cannot be found
  */
-element_result element_interpreter_load_prelude(
+ELEMENT_API element_result element_interpreter_load_prelude(
     element_interpreter_ctx* interpreter);
 
 /**
@@ -163,7 +163,7 @@ element_result element_interpreter_load_prelude(
  *
  * @return ELEMENT_OK interpreter context cleared successfully
  */
-element_result element_interpreter_clear(
+ELEMENT_API element_result element_interpreter_clear(
     element_interpreter_ctx* interpreter);
 
 /**
@@ -176,7 +176,7 @@ element_result element_interpreter_clear(
  * @return ELEMENT_OK set log callback successfully
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter pointer is null
  */
-element_result element_interpreter_set_log_callback(
+ELEMENT_API element_result element_interpreter_set_log_callback(
     element_interpreter_ctx* interpreter,
     element_log_callback log_callback,
     void* user_data);
@@ -190,7 +190,7 @@ element_result element_interpreter_set_log_callback(
  * @return ELEMENT_OK parse only flag set successfully
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter pointer is null
  */
-element_result element_interpreter_set_parse_only(
+ELEMENT_API element_result element_interpreter_set_parse_only(
     element_interpreter_ctx* interpreter,
     bool parse_only);
 
@@ -227,7 +227,7 @@ typedef struct element_instruction element_instruction;
  *
  * @param[in,out] declaration   declaration to delete
  */
-void element_declaration_delete(
+ELEMENT_API void element_declaration_delete(
     element_declaration** declaration);
 
 /**
@@ -235,27 +235,27 @@ void element_declaration_delete(
  *
  * @param[in] instruction       instruction to delete
  */
-void element_instruction_delete(
+ELEMENT_API void element_instruction_delete(
     element_instruction** instruction);
 
 /**
  * @brief gets the size of the instruction (number of element_value's it represents), including the size of any children
  */
-element_result element_instruction_get_size(
+ELEMENT_API element_result element_instruction_get_size(
     const element_instruction* instruction,
     size_t* size);
 
 /**
  * @brief gets the total size of all inputs to the instruction
  */
-element_result element_instruction_get_inputs_size(
+ELEMENT_API element_result element_instruction_get_inputs_size(
     const element_instruction* instruction,
     size_t* size);
 
 /**
  * @brief whether the instruction is a constant (i.e. a literal number) or not
  */
-element_result element_instruction_is_constant(
+ELEMENT_API element_result element_instruction_is_constant(
     const element_instruction* instruction,
     bool* constant);
 
@@ -270,7 +270,7 @@ element_result element_instruction_is_constant(
  * @return ELEMENT_ERROR_API_INVALID_INPUT the buffer_size is NULL
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER the buffer_size is insufficient and a non-NULL buffer was passed
 */
-element_result element_instruction_to_string(
+ELEMENT_API element_result element_instruction_to_string(
     const element_instruction* instruction,
     char* buffer,
     size_t* buffer_size);
@@ -288,7 +288,7 @@ element_result element_instruction_to_string(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL result object pointer is null
  * @return ELEMENT_ERROR_IDENTIFIER_NOT_FOUND path was invalid as nothing was found
  */
-element_result element_interpreter_find(
+ELEMENT_API element_result element_interpreter_find(
     const element_interpreter_ctx* interpreter,
     const char* path,
     element_declaration** declaration);
@@ -304,7 +304,7 @@ element_result element_interpreter_find(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL result object pointer is null
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER buffer size is too small
  */
-element_result element_declaration_get_name(
+ELEMENT_API element_result element_declaration_get_name(
     const element_declaration* decl,
     char* buffer,
     size_t* bufsize);
@@ -320,7 +320,7 @@ element_result element_declaration_get_name(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL result object pointer is null
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER buffer size is too small
  */
-element_result element_declaration_get_qualified_name(
+ELEMENT_API element_result element_declaration_get_qualified_name(
     const element_declaration* decl,
     char* buffer,
     size_t* bufsize);
@@ -337,7 +337,7 @@ element_result element_declaration_get_qualified_name(
  * @return ELEMENT_ERROR_API_INVALID_INPUT the buffer_size is NULL
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER the buffer_size is insufficient and a non-NULL buffer was passed
 */
-element_result element_declaration_to_code(
+ELEMENT_API element_result element_declaration_to_code(
     const element_declaration* declaration,
     bool include_body,
     char* buffer,
@@ -356,7 +356,7 @@ element_result element_declaration_to_code(
  * @return ELEMENT_ERROR_API_DECLARATION_IS_NULL declaration pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL result object pointer is null
  */
-element_result element_interpreter_compile_declaration(
+ELEMENT_API element_result element_interpreter_compile_declaration(
     element_interpreter_ctx* interpreter,
     const element_compiler_options* options,
     const element_declaration* declaration,
@@ -375,7 +375,7 @@ element_result element_interpreter_compile_declaration(
  * @return ELEMENT_ERROR_API_STRING_IS_NULL expression_string is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL instruction is null
  */
-element_result element_interpreter_compile_expression(
+ELEMENT_API element_result element_interpreter_compile_expression(
     element_interpreter_ctx* interpreter,
     const element_compiler_options* options,
     const char* expression_string,
@@ -383,15 +383,15 @@ element_result element_interpreter_compile_expression(
 
 typedef struct element_evaluator_ctx element_evaluator_ctx;
 
-element_result element_evaluator_create(
+ELEMENT_API element_result element_evaluator_create(
     element_interpreter_ctx* interpreter,
     element_evaluator_ctx** evaluator);
 
-element_result element_evaluator_set_options(
+ELEMENT_API element_result element_evaluator_set_options(
     element_evaluator_ctx* evaluator,
     element_evaluator_options options);
 
-element_result element_evaluator_get_options(
+ELEMENT_API element_result element_evaluator_get_options(
     element_evaluator_ctx* evaluator,
     element_evaluator_options* options);
 
@@ -414,7 +414,7 @@ void element_evaluator_delete(
  * @return ELEMENT_ERROR_API_INVALID_INPUT inputs pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL outputs pointer is null
  */
-element_result element_interpreter_evaluate_instruction(
+ELEMENT_API element_result element_interpreter_evaluate_instruction(
     element_interpreter_ctx* interpreter,
     element_evaluator_ctx* evaluator,
     const element_instruction* instruction,
@@ -435,7 +435,7 @@ element_result element_interpreter_evaluate_instruction(
  * @return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL instruction pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT outputs pointer is null
  */
-element_result element_interpreter_evaluate_expression(
+ELEMENT_API element_result element_interpreter_evaluate_expression(
     element_interpreter_ctx* interpreter,
     element_evaluator_ctx* evaluator,
     const char* expression_string,
@@ -455,7 +455,7 @@ element_result element_interpreter_evaluate_expression(
  * @return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL instruction pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT outputs pointer is null
  */
-element_result element_interpreter_evaluate_call_expression(
+ELEMENT_API element_result element_interpreter_evaluate_call_expression(
     element_interpreter_ctx* interpreter,
     element_evaluator_ctx* evaluator,
     const char* call_expression,
@@ -475,7 +475,7 @@ element_result element_interpreter_evaluate_call_expression(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL buffer pointer is null
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER buffer size is too small
  */
-element_result element_interpreter_typeof_expression(
+ELEMENT_API element_result element_interpreter_typeof_expression(
     element_interpreter_ctx* interpreter,
     const char* expression_string,
     char* buffer,

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -246,9 +246,9 @@ ELEMENT_API element_result element_instruction_get_size(
     size_t* size);
 
 /**
- * @brief gets the total size of all inputs to the instruction
+ * @brief gets the total size of all top-level inputs used by the instruction
  */
-ELEMENT_API element_result element_instruction_get_inputs_size(
+ELEMENT_API element_result element_instruction_get_function_inputs_size(
     const element_instruction* instruction,
     size_t* size);
 

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -339,6 +339,7 @@ ELEMENT_API element_result element_declaration_get_qualified_name(
 */
 ELEMENT_API element_result element_declaration_to_code(
     const element_declaration* declaration,
+    bool include_defaults,
     bool include_body,
     char* buffer,
     size_t* buffer_size);

--- a/libelement/include/element/interpreter.h
+++ b/libelement/include/element/interpreter.h
@@ -481,6 +481,15 @@ ELEMENT_API element_result element_interpreter_typeof_expression(
     char* buffer,
     int buffer_size);
 
+
+ELEMENT_API element_result element_interpreter_export_lmnt(
+    element_interpreter_ctx* context,
+    const element_declaration** decls,
+    size_t decls_count,
+    char* buffer,
+    size_t* bufsize);
+
+
     #if defined(__cplusplus)
 }
     #endif

--- a/libelement/include/element/object.h
+++ b/libelement/include/element/object.h
@@ -28,7 +28,7 @@ typedef struct element_ports element_ports;
  *
  * @param[in,out] object        object to delete
 */
-void element_object_delete(element_object** object);
+ELEMENT_API void element_object_delete(element_object** object);
 
 /**
  * @brief object-model context
@@ -45,7 +45,7 @@ typedef struct element_object_model_ctx element_object_model_ctx;
  * @return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL interpreter context pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
 */
-element_result element_object_model_ctx_create(element_interpreter_ctx* interpreter, element_object_model_ctx** output);
+ELEMENT_API element_result element_object_model_ctx_create(element_interpreter_ctx* interpreter, element_object_model_ctx** output);
 
 /**
  * @brief releases memory associated with object-model context and assigns nullptr
@@ -55,7 +55,7 @@ element_result element_object_model_ctx_create(element_interpreter_ctx* interpre
  * @return ELEMENT_OK context deleted successfully
 */
 
-void element_object_model_ctx_delete(element_object_model_ctx** context);
+ELEMENT_API void element_object_model_ctx_delete(element_object_model_ctx** context);
 
 /**
  * @brief wraps a declaration in an object so that it can be assigned as a
@@ -68,7 +68,7 @@ void element_object_model_ctx_delete(element_object_model_ctx** context);
  * @return ELEMENT_ERROR_API_DECLARATION_IS_NULL declaration pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
 */
-element_result element_declaration_to_object(const element_declaration* declaration, element_object** output);
+ELEMENT_API element_result element_declaration_to_object(const element_declaration* declaration, element_object** output);
 
 /**
  * @brief simplify selected object using the provided context
@@ -79,13 +79,13 @@ element_result element_declaration_to_object(const element_declaration* declarat
  * @param[in] object            unsimplified object
  * @param[in] context           object-model context
  * @param[out] output           simplified object
- 
+
  * @return ELEMENT_OK object simplified successfully
  * @return ELEMENT_ERROR_API_OBJECT_MODEL_CTX_IS_NULL context pointer is null
  * @return ELEMENT_ERROR_API_OBJECT_IS_NULL unsimplified object pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output is null
  */
-element_result element_object_simplify(
+ELEMENT_API element_result element_object_simplify(
     const element_object* object,
     element_object_model_ctx* context,
     element_object** output);
@@ -107,7 +107,7 @@ element_result element_object_simplify(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT arguments pointer is null
  */
-element_result element_object_call(
+ELEMENT_API element_result element_object_call(
     const element_object* object,
     element_object_model_ctx* context,
     element_object** arguments,
@@ -128,7 +128,7 @@ element_result element_object_call(
  * @return ELEMENT_ERROR_API_OBJECT_IS_NULL object pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  */
-element_result element_object_call_with_placeholders(
+ELEMENT_API element_result element_object_call_with_placeholders(
     const element_object* object,
     element_object_model_ctx* context,
     element_object** output);
@@ -149,7 +149,7 @@ element_result element_object_call_with_placeholders(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  * @return ELEMENT_ERROR_API_INVALID_INPUT index pointer is null
  */
-element_result element_object_index(
+ELEMENT_API element_result element_object_index(
     const element_object* object,
     element_object_model_ctx* context,
     const char* index,
@@ -168,7 +168,7 @@ element_result element_object_index(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  * @return ELEMENT_ERROR_SERIALISATION object cannot be serialized to an instruction tree
  */
-element_result element_object_to_instruction(
+ELEMENT_API element_result element_object_to_instruction(
     const element_object* object,
     element_object_model_ctx* context,
     element_instruction** output);
@@ -195,7 +195,7 @@ struct element_error
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  * @return ELEMENT_ERROR_API_OBJECT_IS_NOT_ERROR object is not an error
  */
-element_result element_object_to_log_message(
+ELEMENT_API element_result element_object_to_log_message(
     const element_object* object,
     element_log_message* output);
 
@@ -223,14 +223,14 @@ typedef struct element_source_information
  * @return ELEMENT_ERROR_API_OBJECT_IS_NULL object pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output pointer is null
  */
-element_result element_object_get_source_information(
+ELEMENT_API element_result element_object_get_source_information(
     const element_object* object,
     element_source_information* output);
 
 /**
  * @brief gets the name of an object, if it has one. e.g the name of a function or struct
  */
-element_result element_object_get_name(
+ELEMENT_API element_result element_object_get_name(
     const element_object* object,
     char* buffer,
     size_t buffer_size);
@@ -247,7 +247,7 @@ element_result element_object_get_name(
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER buffer size is less than required size
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL buffer pointer is null
  */
-element_result element_object_get_typeof(
+ELEMENT_API element_result element_object_get_typeof(
     const element_object* object,
     char* buffer,
     int buffer_size);
@@ -263,7 +263,7 @@ element_result element_object_get_typeof(
  * @return ELEMENT_ERROR_API_INVALID_INPUT the buffer_size is NULL
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER the buffer_size is insufficient and a non-NULL buffer was passed
 */
-element_result element_object_to_code(
+ELEMENT_API element_result element_object_to_code(
     const element_object* object,
     char* buffer,
     size_t* buffer_size);
@@ -273,7 +273,7 @@ element_result element_object_to_code(
  *
  * The lifetime of the returned ports object is the same as that of the object it is retrieved from.
  */
-element_result element_object_get_inputs(
+ELEMENT_API element_result element_object_get_inputs(
     const element_object* object,
     const element_ports** inputs);
 
@@ -282,7 +282,7 @@ element_result element_object_get_inputs(
  *
  * The lifetime of the returned port is the same as that of the object it is retrieved from.
  */
-element_result element_object_get_output(
+ELEMENT_API element_result element_object_get_output(
     const element_object* object,
     const element_port** output);
 
@@ -291,7 +291,7 @@ element_result element_object_get_output(
  *
  * The lifetime of the returned port is the same as that of the ports structure it is retrieved from.
  */
-element_result element_ports_get_port(
+ELEMENT_API element_result element_ports_get_port(
     const element_ports* ports,
     size_t index,
     const element_port** port);
@@ -299,28 +299,28 @@ element_result element_ports_get_port(
 /**
  * @brief gets the number of ports in the list
  */
-element_result element_ports_get_count(
+ELEMENT_API element_result element_ports_get_count(
     const element_ports* ports,
     size_t* count);
 
 /**
  * @brief gets the name of the port if it has one (such as the parameter name), otherwise empty string
  */
-element_result element_port_get_name(
+ELEMENT_API element_result element_port_get_name(
     const element_port* port,
     const char** name);
 
 /**
  * @brief gets the string in source of the type, e.g. func(a:MyNamespace.MyStruct) returns "MyNamespace.MyStruct"
  */
-element_result element_port_get_constraint_annotation(
+ELEMENT_API element_result element_port_get_constraint_annotation(
     const element_port* port,
     const char** annotation);
 
 /**
  * @brief gets the constraint after interpreting the annotation, e,g. func(a:MyNamespace.MyStruct) returns an object that is the "MyStruct" struct
  */
-element_result element_port_get_constraint_object(
+ELEMENT_API element_result element_port_get_constraint_object(
     const element_port* port,
     element_object_model_ctx* object_model_context,
     element_object** object);
@@ -328,7 +328,7 @@ element_result element_port_get_constraint_object(
 /**
  * @brief gets the default after interpreting, e,g. func(a:Num = 5.add(2)) returns an object that is a "Num" with the value "7"
  */
-element_result element_port_get_default_object(
+ELEMENT_API element_result element_port_get_default_object(
     const element_port* port,
     element_object_model_ctx* object_model_context,
     element_object** object);

--- a/libelement/include/element/parser.h
+++ b/libelement/include/element/parser.h
@@ -24,7 +24,7 @@ typedef struct element_parser_ctx element_parser_ctx;
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL parser pointer is null
  */
-element_result element_parser_create(
+ELEMENT_API element_result element_parser_create(
     element_tokeniser_ctx* tokeniser,
     element_parser_ctx** parser);
 
@@ -33,7 +33,7 @@ element_result element_parser_create(
  *
  * @param[in,out] parser            parser context
  */
-void element_parser_delete(
+ELEMENT_API void element_parser_delete(
     element_parser_ctx** parser);
 
 /**
@@ -46,7 +46,7 @@ void element_parser_delete(
  * @return ELEMENT_ERROR_API_PARSER_CTX_IS_NULL parser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL ast node pointer is null
  */
-element_result element_parser_get_ast(
+ELEMENT_API element_result element_parser_get_ast(
     element_parser_ctx* parser,
     element_ast** ast);
 
@@ -58,7 +58,7 @@ element_result element_parser_get_ast(
  * @return ELEMENT_OK ast tree created successfully
  * @return ELEMENT_ERROR_API_PARSER_CTX_IS_NULL parser pointer is null
  */
-element_result element_parser_build_ast(
+ELEMENT_API element_result element_parser_build_ast(
     element_parser_ctx* parser);
 
     #if defined(__cplusplus)

--- a/libelement/include/element/token.h
+++ b/libelement/include/element/token.h
@@ -61,7 +61,7 @@ typedef struct element_tokeniser_ctx element_tokeniser_ctx;
  * @return ELEMENT_OK created an interpreter successfully
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL tokeniser pointer is null
  */
-element_result element_tokeniser_create(
+ELEMENT_API element_result element_tokeniser_create(
     element_tokeniser_ctx** tokeniser);
 
 /**
@@ -69,7 +69,7 @@ element_result element_tokeniser_create(
  *
  * @param[in,out] tokeniser     tokeniser context 
  */
-void element_tokeniser_delete(
+ELEMENT_API void element_tokeniser_delete(
     element_tokeniser_ctx** tokeniser);
 
 /**
@@ -88,7 +88,7 @@ void element_tokeniser_delete(
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_STRING_IS_NULL source_name pointer is null
  */
-element_result element_tokeniser_run(
+ELEMENT_API element_result element_tokeniser_run(
     element_tokeniser_ctx* tokeniser,
     const char* input,
     const char* source_name);
@@ -101,7 +101,7 @@ element_result element_tokeniser_run(
  * @return ELEMENT_OK tokeniser cleared successfully
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  */
-element_result element_tokeniser_clear(
+ELEMENT_API element_result element_tokeniser_clear(
     element_tokeniser_ctx* tokeniser);
 
 /**
@@ -114,7 +114,7 @@ element_result element_tokeniser_clear(
  * @return ELEMENT_OK set log callback successfully
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  */
-element_result element_tokeniser_set_log_callback(
+ELEMENT_API element_result element_tokeniser_set_log_callback(
     element_tokeniser_ctx* tokeniser,
     element_log_callback log_callback,
     void* user_data);
@@ -129,7 +129,7 @@ element_result element_tokeniser_set_log_callback(
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL source_name pointer is null
  */
-element_result element_tokeniser_get_source_name(
+ELEMENT_API element_result element_tokeniser_get_source_name(
     const element_tokeniser_ctx* tokeniser,
     const char** source_name);
 
@@ -143,7 +143,7 @@ element_result element_tokeniser_get_source_name(
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL input pointer is null
  */
-element_result element_tokeniser_get_input(
+ELEMENT_API element_result element_tokeniser_get_input(
     const element_tokeniser_ctx* tokeniser,
     const char** input);
 
@@ -157,7 +157,7 @@ element_result element_tokeniser_get_input(
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL token count pointer is null
  */
-element_result element_tokeniser_get_token_count(
+ELEMENT_API element_result element_tokeniser_get_token_count(
     const element_tokeniser_ctx* tokeniser,
     size_t* count);
 
@@ -173,7 +173,7 @@ element_result element_tokeniser_get_token_count(
  * @return ELEMENT_ERROR_API_TOKENISER_CTX_IS_NULL tokeniser pointer is null
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL token count pointer is null
  */
-element_result element_tokeniser_get_token(
+ELEMENT_API element_result element_tokeniser_get_token(
     const element_tokeniser_ctx* tokeniser,
     size_t index,
     const element_token** token,
@@ -200,7 +200,7 @@ element_result element_tokeniser_get_token(
  * @return ELEMENT_ERROR_API_OUTPUT_IS_NULL output buffer pointer is null
  * @return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER buffer size too small
  */
-element_result element_tokeniser_to_string(
+ELEMENT_API element_result element_tokeniser_to_string(
     const element_tokeniser_ctx* tokeniser,
     const element_token* token_to_mark,
     char* output_buffer,

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -205,7 +205,8 @@ element_result element_instruction_get_size(const element_instruction* instructi
 static int get_max_top_level_input_index(const element::instruction* instruction)
 {
     int result = -1;
-    if (!instruction) return result;
+    if (!instruction)
+        return result;
 
     auto ii = instruction->as<element::instruction_input>();
     if (ii && ii->scope() == 0) {

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -355,6 +355,7 @@ element_result element_declaration_get_qualified_name(const element_declaration*
 
 element_result element_declaration_to_code(
     const element_declaration* declaration,
+    bool include_defaults,
     bool include_body,
     char* buffer,
     size_t* buffer_size)
@@ -368,7 +369,7 @@ element_result element_declaration_to_code(
     std::string string;
     auto fdecl = dynamic_cast<const element::function_declaration*>(declaration->decl);
     if (fdecl)
-        string = fdecl->to_code(0, include_body);
+        string = fdecl->to_code(0, include_defaults, include_body);
     else
         string = declaration->decl->to_code(0);
 

--- a/libelement/src/interpreter.cpp
+++ b/libelement/src/interpreter.cpp
@@ -202,7 +202,24 @@ element_result element_instruction_get_size(const element_instruction* instructi
     return ELEMENT_OK;
 }
 
-element_result element_instruction_get_inputs_size(const element_instruction* instruction, size_t* size)
+static int get_max_top_level_input_index(const element::instruction* instruction)
+{
+    int result = -1;
+    if (!instruction) return result;
+
+    auto ii = instruction->as<element::instruction_input>();
+    if (ii && ii->scope() == 0) {
+        result = static_cast<int>(ii->index());
+    }
+
+    for (const auto& d : instruction->dependents()) {
+        result = (std::max)(result, get_max_top_level_input_index(d.get()));
+    }
+
+    return result;
+}
+
+element_result element_instruction_get_function_inputs_size(const element_instruction* instruction, size_t* size)
 {
     if (!instruction || !instruction->instruction)
         return ELEMENT_ERROR_API_INSTRUCTION_IS_NULL;
@@ -210,9 +227,7 @@ element_result element_instruction_get_inputs_size(const element_instruction* in
     if (!size)
         return ELEMENT_ERROR_API_OUTPUT_IS_NULL;
 
-    *size = 0;
-    for (const auto& d : instruction->instruction->dependents())
-        *size += d->get_size();
+    *size = static_cast<size_t>(get_max_top_level_input_index(instruction->instruction.get()) + 1);
     return ELEMENT_OK;
 }
 

--- a/libelement/src/lmnt/compiler.cpp
+++ b/libelement/src/lmnt/compiler.cpp
@@ -1337,6 +1337,7 @@ element_result element_lmnt_find_constants(
 element_result element_lmnt_compile_function(
     const element_lmnt_compiler_ctx& ctx,
     const element::instruction_const_shared_ptr instruction,
+    std::string name,
     std::vector<element_value>& constants,
     const size_t inputs_count,
     element_lmnt_compiled_function& output)
@@ -1355,5 +1356,6 @@ element_result element_lmnt_compile_function(
 
     output.outputs_count = vr->count;
     output.local_stack_count = state.allocator->get_max_stack_usage();
+    output.name = std::move(name);
     return ELEMENT_OK;
 }

--- a/libelement/src/lmnt/compiler.hpp
+++ b/libelement/src/lmnt/compiler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 #include "instruction_tree/instructions.hpp"
 #include "lmnt/archive.h"
@@ -19,6 +20,7 @@ struct element_lmnt_compiler_ctx
 
 struct element_lmnt_compiled_function
 {
+    std::string name;
     std::vector<lmnt_instruction> instructions;
     size_t local_stack_count = 0;
     size_t inputs_count = 0;
@@ -36,6 +38,7 @@ element_result element_lmnt_find_constants(
 element_result element_lmnt_compile_function(
     const element_lmnt_compiler_ctx& ctx,
     const element::instruction_const_shared_ptr instruction,
+    std::string name,
     std::vector<element_value>& constants,
     const size_t inputs_count,
     element_lmnt_compiled_function& output);

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -113,11 +113,17 @@ struct instruction_deleter
     }
 };
 
-element_result element_interpreter_export_lmnt(element_interpreter_ctx* context, const element_declaration** decls, size_t decls_count, char* buffer, size_t* bufsize)
+element_result element_interpreter_export_lmnt(
+    element_interpreter_ctx* context,
+    const element_declaration** decls,
+    const char** funcnames,
+    size_t decls_count,
+    char* buffer,
+    size_t* bufsize)
 {
     if (!context)
         return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL;
-    if (!decls)
+    if (!decls || !funcnames)
         return ELEMENT_ERROR_API_DECLARATION_IS_NULL;
     if (decls_count == 0)
         return ELEMENT_ERROR_API_INVALID_INPUT;

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -153,7 +153,7 @@ element_result element_interpreter_export_lmnt(element_interpreter_ctx* context,
 
     for (size_t i = 0; i < functions.size(); ++i) {
         size_t inputs_size = 0;
-        ELEMENT_OK_OR_RETURN(element_instruction_get_inputs_size(functions[i].get(), &inputs_size));
+        ELEMENT_OK_OR_RETURN(element_instruction_get_function_inputs_size(functions[i].get(), &inputs_size));
 
         size_t outputs_size = 0;
         ELEMENT_OK_OR_RETURN(element_instruction_get_size(functions[i].get(), &outputs_size));

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -1,0 +1,175 @@
+#include <element/element.h>
+#include <interpreter_internal.hpp>
+#include <iostream>
+#include <fstream>
+
+#include "lmnt/opcodes.h"
+#include "lmnt/archive.h"
+#include "lmnt/interpreter.h"
+#include "lmnt/compiler.hpp"
+#include "lmnt/jit.h"
+
+
+// TODO: support data sections?
+
+static std::vector<char> create_archive(
+    const std::vector<element_lmnt_compiled_function>& defs,
+    const std::vector<lmnt_value>& constants)
+{
+    // each element is [size_lo, size_hi, 'a', 'b', 'c', ..., '\0'] - so 2 + length + 1
+    const size_t names_len = std::accumulate(defs.begin(), defs.end(), 0ULL,
+        [](size_t i, const element_lmnt_compiled_function& d) { return i + LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4); });
+    const size_t all_instr_count = std::accumulate(defs.begin(), defs.end(), 0ULL,
+        [](size_t i, const element_lmnt_compiled_function& d) { return i + d.instructions.size(); });
+    const size_t consts_count = constants.size();
+    const size_t data_count = 0;
+    assert(names_len <= 0xFC);
+    assert(all_instr_count <= 0x3FFFFFF0);
+    assert(consts_count <= 0x3FFFFFFF);
+
+    const size_t header_len = 0x1C;
+    const size_t strings_len = names_len;
+    const size_t defs_len = 0x10 * defs.size();
+    const size_t code_len = 0x04 * defs.size() + all_instr_count * sizeof(lmnt_instruction);
+    const lmnt_loffset data_sec_count = 0;
+    const size_t data_len = 0x04 + data_sec_count * (0x08 + 0x04 * data_count);
+    const size_t consts_len = consts_count * sizeof(lmnt_value);
+
+    const size_t total_size = header_len + strings_len + defs_len + code_len + data_len + consts_len;
+    std::vector<char> buf;
+    buf.resize(total_size);
+
+    size_t idx = 0;
+    const char header[] = {
+        'L', 'M', 'N', 'T',
+        0x00, 0x00, 0x00, 0x00,
+        char(strings_len & 0xFF), char((strings_len >> 8) & 0xFF), char((strings_len >> 16) & 0xFF), char((strings_len >> 24) & 0xFF), // strings length
+        char(defs_len & 0xFF), char((defs_len >> 8) & 0xFF), char((defs_len >> 16) & 0xFF), char((defs_len >> 24) & 0xFF),             // defs length
+        char(code_len & 0xFF), char((code_len >> 8) & 0xFF), char((code_len >> 16) & 0xFF), char((code_len >> 24) & 0xFF),             // code length
+        char(data_len & 0xFF), char((data_len >> 8) & 0xFF), char((data_len >> 16) & 0xFF), char((data_len >> 24) & 0xFF),             // data length
+        char(consts_len & 0xFF), char((consts_len >> 8) & 0xFF), char((consts_len >> 16) & 0xFF), char((consts_len >> 24) & 0xFF)      // constants_length
+    };
+    memcpy(buf.data() + idx, header, sizeof(header));
+    idx += sizeof(header);
+
+    size_t strings_start = idx;
+    for (const auto& d : defs) {
+        const size_t name_len = d.name.length();
+        const size_t name_len_padded = LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4) - 2;
+        buf[idx++] = char((name_len_padded) & 0xFF);
+        buf[idx++] = char(((name_len_padded) >> 8) & 0xFF);
+
+        memcpy(buf.data() + idx, d.name.data(), name_len);
+        idx += name_len;
+        buf[idx++] = '\0';
+        while (idx % 4)
+            buf[idx++] = '\0';
+    }
+
+    size_t string_idx = 0;
+    size_t code_idx = 0;
+    for (const auto& d : defs) {
+        lmnt_def def;
+        def.name = lmnt_offset(string_idx);
+        def.flags = d.flags;
+        def.code = lmnt_loffset(code_idx);
+        def.stack_count = lmnt_offset(d.total_stack_count());
+        def.args_count = lmnt_offset(d.inputs_count);
+        def.rvals_count = lmnt_offset(d.outputs_count);
+        def.default_args_index = lmnt_offset(0);
+
+        memcpy(buf.data() + idx, &def, sizeof(def));
+        idx += sizeof(def);
+        string_idx += LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4);
+        code_idx += (0x04 + d.instructions.size() * sizeof(lmnt_instruction));
+    }
+
+    for (const auto& d : defs) {
+        uint32_t instr_count = uint32_t(d.instructions.size());
+        memcpy(buf.data() + idx, &instr_count, sizeof(uint32_t));
+        idx += sizeof(uint32_t);
+
+        memcpy(buf.data() + idx, d.instructions.data(), instr_count * sizeof(lmnt_instruction));
+        idx += instr_count * sizeof(lmnt_instruction);
+    }
+
+    // TODO: data sections
+    memcpy(buf.data() + idx, (const char*)(&data_sec_count), sizeof(lmnt_loffset));
+    idx += sizeof(lmnt_loffset);
+
+    memcpy(buf.data() + idx, constants.data(), consts_count * sizeof(lmnt_value));
+    idx += consts_count * sizeof(lmnt_value);
+
+    assert(idx == total_size);
+
+    return buf;
+}
+
+struct instruction_deleter
+{
+    void operator()(element_instruction* instr)
+    {
+        element_instruction_delete(&instr);
+    }
+};
+
+element_result element_interpreter_export_lmnt(element_interpreter_ctx* context, const element_declaration** decls, size_t decls_count, char* buffer, size_t* bufsize)
+{
+    if (!context)
+        return ELEMENT_ERROR_API_INTERPRETER_CTX_IS_NULL;
+    if (!decls)
+        return ELEMENT_ERROR_API_DECLARATION_IS_NULL;
+    if (decls_count == 0)
+        return ELEMENT_ERROR_API_INVALID_INPUT;
+    if (!bufsize)
+        return ELEMENT_ERROR_API_OUTPUT_IS_NULL;
+
+    using instruction = std::unique_ptr<element_instruction, instruction_deleter>;
+    std::vector<instruction> functions;
+    functions.reserve(decls_count);
+
+    for (size_t i = 0; i < decls_count; ++i) {
+        element_instruction* instr;
+        ELEMENT_OK_OR_RETURN(element_interpreter_compile_declaration(context, nullptr, decls[i], &instr));
+        functions.emplace_back(instr);
+    }
+
+    element_lmnt_compiler_ctx lmnt_ctx;
+
+    std::unordered_map<element_value, size_t> candidate_constants;
+    for (size_t i = 0; i < functions.size(); ++i) {
+        ELEMENT_OK_OR_RETURN(element_lmnt_find_constants(lmnt_ctx, functions[i]->instruction, candidate_constants));
+    }
+
+    std::vector<element_lmnt_compiled_function> lmnt_functions(functions.size());
+    std::vector<element_value> constants;
+    constants.reserve(candidate_constants.size());
+    static const size_t constant_threshold = 1;
+
+    for (const auto& [value, count] : candidate_constants) {
+        if (count >= constant_threshold)
+            constants.push_back(value);
+    }
+
+    for (size_t i = 0; i < functions.size(); ++i) {
+        size_t inputs_size = 0;
+        ELEMENT_OK_OR_RETURN(element_instruction_get_inputs_size(functions[i].get(), &inputs_size));
+
+        size_t outputs_size = 0;
+        ELEMENT_OK_OR_RETURN(element_instruction_get_size(functions[i].get(), &outputs_size));
+
+        std::string name = decls[i]->decl->get_name(); // get_qualified_name() ?
+        ELEMENT_OK_OR_RETURN(element_lmnt_compile_function(lmnt_ctx, functions[i]->instruction, name, constants, inputs_size, lmnt_functions[i]));
+    }
+
+    auto lmnt_archive_data = create_archive(lmnt_functions, constants);
+
+    if (buffer && lmnt_archive_data.size() > *bufsize)
+        return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
+
+    *bufsize = lmnt_archive_data.size();
+    if (buffer)
+        memcpy(buffer, lmnt_archive_data.data(), lmnt_archive_data.size());
+
+    return ELEMENT_OK;
+}

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -72,8 +72,8 @@ static std::vector<char> create_archive(
         const size_t name_len = d.name.length();
         // we need the padded length of the string *without* the length bytes, so -2 at the end
         const size_t name_len_padded = LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4) - 2;
-        buf[idx++] = char((name_len_padded) & 0xFF);
-        buf[idx++] = char(((name_len_padded) >> 8) & 0xFF);
+        buf[idx++] = char((name_len_padded >> 0) & 0xFF);
+        buf[idx++] = char((name_len_padded >> 8) & 0xFF);
 
         memcpy(buf.data() + idx, d.name.data(), name_len);
         idx += name_len;

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -160,20 +160,22 @@ element_result element_interpreter_export_lmnt(
     for (size_t i = 0; i < functions.size(); ++i) {
         size_t inputs_size = 0;
         ELEMENT_OK_OR_RETURN(element_instruction_get_function_inputs_size(functions[i].get(), &inputs_size));
-
         size_t outputs_size = 0;
         ELEMENT_OK_OR_RETURN(element_instruction_get_size(functions[i].get(), &outputs_size));
 
-        std::string name = decls[i]->decl->get_name(); // get_qualified_name() ?
-        ELEMENT_OK_OR_RETURN(element_lmnt_compile_function(lmnt_ctx, functions[i]->instruction, name, constants, inputs_size, lmnt_functions[i]));
+        ELEMENT_OK_OR_RETURN(element_lmnt_compile_function(lmnt_ctx, functions[i]->instruction, funcnames[i], constants, inputs_size, lmnt_functions[i]));
     }
 
     auto lmnt_archive_data = create_archive(lmnt_functions, constants);
 
-    if (buffer && lmnt_archive_data.size() > *bufsize)
-        return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
-
+    size_t current_bufsize = *bufsize;
     *bufsize = lmnt_archive_data.size();
+
+    if (buffer && lmnt_archive_data.size() > current_bufsize) {
+        *bufsize = lmnt_archive_data.size();
+        return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
+    }
+
     if (buffer)
         memcpy(buffer, lmnt_archive_data.data(), lmnt_archive_data.size());
 

--- a/libelement/src/lmnt/exporter.cpp
+++ b/libelement/src/lmnt/exporter.cpp
@@ -17,8 +17,10 @@ static std::vector<char> create_archive(
     const std::vector<lmnt_value>& constants)
 {
     // each element is [size_lo, size_hi, 'a', 'b', 'c', ..., '\0'] - so 2 + length + 1
+    // each element must also be 4-byte aligned
     const size_t names_len = std::accumulate(defs.begin(), defs.end(), 0ULL,
         [](size_t i, const element_lmnt_compiled_function& d) { return i + LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4); });
+    // total length of all instructions in the code table (not including headers)
     const size_t all_instr_count = std::accumulate(defs.begin(), defs.end(), 0ULL,
         [](size_t i, const element_lmnt_compiled_function& d) { return i + d.instructions.size(); });
     const size_t consts_count = constants.size();
@@ -29,39 +31,55 @@ static std::vector<char> create_archive(
 
     const size_t header_len = 0x1C;
     const size_t strings_len = names_len;
+    // defs are constant size
     const size_t defs_len = 0x10 * defs.size();
+    // code table entries are 4 bytes of header and then instructions
     const size_t code_len = 0x04 * defs.size() + all_instr_count * sizeof(lmnt_instruction);
+    // we always write the number of data sections even if that number is zero
     const lmnt_loffset data_sec_count = 0;
     const size_t data_len = 0x04 + data_sec_count * (0x08 + 0x04 * data_count);
+    // constants are just raw data
     const size_t consts_len = consts_count * sizeof(lmnt_value);
 
+    // total size must be equal to the header + the tables
+    // we sanity-check against this at the end
     const size_t total_size = header_len + strings_len + defs_len + code_len + data_len + consts_len;
     std::vector<char> buf;
     buf.resize(total_size);
 
+    // track current index in the output buffer
     size_t idx = 0;
-    const char header[] = {
-        'L', 'M', 'N', 'T',
-        0x00, 0x00, 0x00, 0x00,
-        char(strings_len & 0xFF), char((strings_len >> 8) & 0xFF), char((strings_len >> 16) & 0xFF), char((strings_len >> 24) & 0xFF), // strings length
-        char(defs_len & 0xFF), char((defs_len >> 8) & 0xFF), char((defs_len >> 16) & 0xFF), char((defs_len >> 24) & 0xFF),             // defs length
-        char(code_len & 0xFF), char((code_len >> 8) & 0xFF), char((code_len >> 16) & 0xFF), char((code_len >> 24) & 0xFF),             // code length
-        char(data_len & 0xFF), char((data_len >> 8) & 0xFF), char((data_len >> 16) & 0xFF), char((data_len >> 24) & 0xFF),             // data length
-        char(consts_len & 0xFF), char((consts_len >> 8) & 0xFF), char((consts_len >> 16) & 0xFF), char((consts_len >> 24) & 0xFF)      // constants_length
-    };
-    memcpy(buf.data() + idx, header, sizeof(header));
+
+    lmnt_archive_header header;
+    memset(&header, 0, sizeof(header));
+    header.magic[0] = 'L';
+    header.magic[1] = 'M';
+    header.magic[2] = 'N';
+    header.magic[3] = 'T';
+    header.version_major = 0;
+    header.version_minor = 0;
+    header.strings_length = static_cast<uint32_t>(strings_len);
+    header.defs_length = static_cast<uint32_t>(defs_len);
+    header.code_length = static_cast<uint32_t>(code_len);
+    header.data_length = static_cast<uint32_t>(data_len);
+    header.constants_length = static_cast<uint32_t>(consts_len);
+
+    memcpy(buf.data() + idx, &header, sizeof(header));
     idx += sizeof(header);
 
     size_t strings_start = idx;
     for (const auto& d : defs) {
         const size_t name_len = d.name.length();
+        // we need the padded length of the string *without* the length bytes, so -2 at the end
         const size_t name_len_padded = LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4) - 2;
         buf[idx++] = char((name_len_padded) & 0xFF);
         buf[idx++] = char(((name_len_padded) >> 8) & 0xFF);
 
         memcpy(buf.data() + idx, d.name.data(), name_len);
         idx += name_len;
+        // always add a null...
         buf[idx++] = '\0';
+        // ... and then pad to 4-byte alignment
         while (idx % 4)
             buf[idx++] = '\0';
     }
@@ -80,7 +98,10 @@ static std::vector<char> create_archive(
 
         memcpy(buf.data() + idx, &def, sizeof(def));
         idx += sizeof(def);
+        // we wrote the strings in the same order we're writing the defs
+        // so we can get away with just upping the index with each one
         string_idx += LMNT_ROUND_UP(0x02 + d.name.length() + 1, 4);
+        // we'll also write the code in the same order
         code_idx += (0x04 + d.instructions.size() * sizeof(lmnt_instruction));
     }
 
@@ -142,6 +163,7 @@ element_result element_interpreter_export_lmnt(
 
     element_lmnt_compiler_ctx lmnt_ctx;
 
+    // we need to get all the constants we want in the archive ahead of time, from all functions
     std::unordered_map<element_value, size_t> candidate_constants;
     for (size_t i = 0; i < functions.size(); ++i) {
         ELEMENT_OK_OR_RETURN(element_lmnt_find_constants(lmnt_ctx, functions[i]->instruction, candidate_constants));
@@ -160,8 +182,6 @@ element_result element_interpreter_export_lmnt(
     for (size_t i = 0; i < functions.size(); ++i) {
         size_t inputs_size = 0;
         ELEMENT_OK_OR_RETURN(element_instruction_get_function_inputs_size(functions[i].get(), &inputs_size));
-        size_t outputs_size = 0;
-        ELEMENT_OK_OR_RETURN(element_instruction_get_size(functions[i].get(), &outputs_size));
 
         ELEMENT_OK_OR_RETURN(element_lmnt_compile_function(lmnt_ctx, functions[i]->instruction, funcnames[i], constants, inputs_size, lmnt_functions[i]));
     }
@@ -169,15 +189,16 @@ element_result element_interpreter_export_lmnt(
     auto lmnt_archive_data = create_archive(lmnt_functions, constants);
 
     size_t current_bufsize = *bufsize;
+    // always write the size of the archive back out to the user
     *bufsize = lmnt_archive_data.size();
 
-    if (buffer && lmnt_archive_data.size() > current_bufsize) {
-        *bufsize = lmnt_archive_data.size();
-        return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
-    }
+    // if the user gave us a buffer, check it's big enough and write to it
+    if (buffer) {
+        if (lmnt_archive_data.size() > current_bufsize)
+            return ELEMENT_ERROR_API_INSUFFICIENT_BUFFER;
 
-    if (buffer)
         memcpy(buffer, lmnt_archive_data.data(), lmnt_archive_data.size());
+    }
 
     return ELEMENT_OK;
 }

--- a/libelement/src/object_model/declarations/function_declaration.hpp
+++ b/libelement/src/object_model/declarations/function_declaration.hpp
@@ -27,7 +27,7 @@ public:
 
     [[nodiscard]] std::string typeof_info() const override;
     [[nodiscard]] std::string to_code(const int depth) const override;
-    [[nodiscard]] std::string to_code(const int depth, bool include_body) const;
+    [[nodiscard]] std::string to_code(const int depth, bool include_defaults, bool include_body) const;
     [[nodiscard]] std::string to_string() const override;
     [[nodiscard]] bool is_variadic() const override;
 

--- a/libelement/src/object_model/metainfo.cpp
+++ b/libelement/src/object_model/metainfo.cpp
@@ -176,10 +176,10 @@ std::string constraint_declaration::to_code(const int depth) const
 
 std::string function_declaration::to_code(const int depth) const
 {
-    return to_code(depth, true);
+    return to_code(depth, true, true);
 }
 
-std::string function_declaration::to_code(const int depth, bool include_body) const
+std::string function_declaration::to_code(const int depth, bool include_defaults, bool include_body) const
 {
     auto declaration = name.value;
 
@@ -191,8 +191,8 @@ std::string function_declaration::to_code(const int depth, bool include_body) co
 
     std::string ports;
     if (has_inputs()) {
-        static constexpr auto accumulate = [](std::string accumulator, const port& port) {
-            return std::move(accumulator) + ", " + port.typeof_info() + (port.has_default() ? " = " + port.get_default()->to_code() : "");
+        static const auto accumulate = [include_defaults](std::string accumulator, const port& port) {
+            return std::move(accumulator) + ", " + port.typeof_info() + (include_defaults && port.has_default() ? " = " + port.get_default()->to_code() : "");
         };
 
         const auto input_ports = std::accumulate(

--- a/libelement/test/lmnt_test.cpp
+++ b/libelement/test/lmnt_test.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
 
     printf("%s", output_buffer);
 
-    result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, constants, args.size(), lmnt_output);
+    result = element_lmnt_compile_function(lmnt_ctx, instruction->instruction, "evaluate", constants, args.size(), lmnt_output);
     if (result != ELEMENT_OK) {
         printf("RUH ROH: %d\n", result);
         goto cleanup;
@@ -222,7 +222,7 @@ int main(int argc, char** argv)
     printf("Inputs: %zu, outputs: %zu, locals: %zu\n", lmnt_output.inputs_count, lmnt_output.outputs_count, lmnt_output.local_stack_count);
 
     {
-        auto lmnt_archive_data = create_archive("evaluate", uint16_t(args.size()), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions, lmnt_output.flags);
+        auto lmnt_archive_data = create_archive(lmnt_output.name.c_str(), uint16_t(args.size()), uint16_t(output.count), uint16_t(lmnt_output.total_stack_count()), constants, lmnt_output.instructions, lmnt_output.flags);
 
         std::vector<char> lmnt_stack(32768);
         lmnt_ictx lctx;


### PR DESCRIPTION
- Adds API function to generate an LMNT archive from one or more Element declarations
- Adds exporting of API functions when built as a shared library
- Turns off max empty lines in clang-format
- Turns off a couple of cast options in clang-format since they were misidentifying a variable in brackets as a type/cast