### PR TITLE
Updated Windows CI build target to VS2022 and pin to windows-2022 version

### DIFF
--- a/.github/workflows/libelement.CLI.yml
+++ b/.github/workflows/libelement.CLI.yml
@@ -28,13 +28,13 @@ jobs:
             generators: "Ninja",
           }
         - {
-            name: "windows-msvc-vs2019",
-            os: windows-latest,
+            name: "windows-msvc-vs2022",
+            os: windows-2022,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-            generators: "Visual Studio 16 2019"
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            generators: "Visual Studio 17 2022"
           }
         - {
             name: "macos-clang",

--- a/.github/workflows/libelement.yml
+++ b/.github/workflows/libelement.yml
@@ -28,13 +28,13 @@ jobs:
             generators: "Ninja",
           }
         - {
-            name: "windows-msvc-vs2019",
-            os: windows-latest,
+            name: "windows-msvc-vs2022",
+            os: windows-2022,
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-            generators: "Visual Studio 16 2019"
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            generators: "Visual Studio 17 2022"
           }
         - {
             name: "macos-clang",


### PR DESCRIPTION
Previously we were targeting `windows-latest` and specifying VS2019 as our CMake generator; `windows-latest` has been updated to match `windows-2022` which has VS2022.

This change updates the build to build using VS2022 and pins the image we use for building to be `windows-2022` so this doesn't break when `windows-latest` next updates.